### PR TITLE
feat(telegram): agregar bot básico para consultar partidos

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,3 +24,6 @@ DEBUG=true
 JWT_SECRET_KEY=cambiar-en-produccion-clave-segura
 JWT_ALGORITHM=HS256
 JWT_EXPIRE_MINUTES=60
+
+# Telegram Bot (opcional — si vacío, el bot no inicia)
+TELEGRAM_BOT_TOKEN=

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -25,6 +25,9 @@ class Settings(BaseSettings):
     jwt_algorithm: str = "HS256"
     jwt_expire_minutes: int = 60
 
+    # Telegram Bot (opcional — si vacío, el bot no inicia)
+    telegram_bot_token: str = ""
+
     class Config:
         env_file = ".env"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,8 +34,8 @@ async def lifespan(app: FastAPI):
             await bot_app.start()
             await bot_app.updater.start_polling()
             logger.info("Telegram Bot iniciado")
-        except Exception as e:
-            logger.error(f"Error iniciando Telegram Bot: {e}")
+        except Exception:
+            logger.exception("Error iniciando Telegram Bot")
             bot_app = None
 
     logger.info(f"OddsEngine v1.0.0 iniciado — modo: {settings.data_mode}")
@@ -47,8 +47,8 @@ async def lifespan(app: FastAPI):
             await bot_app.stop()
             await bot_app.shutdown()
             logger.info("Telegram Bot detenido")
-        except Exception as e:
-            logger.error(f"Error deteniendo Telegram Bot: {e}")
+        except Exception:
+            logger.exception("Error deteniendo Telegram Bot")
 
     logger.info("OddsEngine detenido")
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,8 +24,32 @@ async def lifespan(app: FastAPI):
         from app.core.database import create_tables
         await create_tables()
         logger.info("Tablas PostgreSQL verificadas")
+
+    bot_app = None
+    if settings.telegram_bot_token:
+        try:
+            from app.telegram import create_bot_application
+            bot_app = create_bot_application(settings.telegram_bot_token)
+            await bot_app.initialize()
+            await bot_app.start()
+            await bot_app.updater.start_polling()
+            logger.info("Telegram Bot iniciado")
+        except Exception as e:
+            logger.error(f"Error iniciando Telegram Bot: {e}")
+            bot_app = None
+
     logger.info(f"OddsEngine v1.0.0 iniciado — modo: {settings.data_mode}")
     yield
+
+    if bot_app:
+        try:
+            await bot_app.updater.stop()
+            await bot_app.stop()
+            await bot_app.shutdown()
+            logger.info("Telegram Bot detenido")
+        except Exception as e:
+            logger.error(f"Error deteniendo Telegram Bot: {e}")
+
     logger.info("OddsEngine detenido")
 
 

--- a/backend/app/telegram/__init__.py
+++ b/backend/app/telegram/__init__.py
@@ -1,0 +1,3 @@
+from app.telegram.bot import create_bot_application
+
+__all__ = ["create_bot_application"]

--- a/backend/app/telegram/bot.py
+++ b/backend/app/telegram/bot.py
@@ -1,0 +1,19 @@
+from telegram.ext import ApplicationBuilder, CommandHandler
+
+from app.telegram.handlers import (
+    start_handler,
+    help_handler,
+    health_handler,
+    matches_handler,
+    match_handler,
+)
+
+
+def create_bot_application(token: str):
+    application = ApplicationBuilder().token(token).build()
+    application.add_handler(CommandHandler("start", start_handler))
+    application.add_handler(CommandHandler("help", help_handler))
+    application.add_handler(CommandHandler("health", health_handler))
+    application.add_handler(CommandHandler("matches", matches_handler))
+    application.add_handler(CommandHandler("match", match_handler))
+    return application

--- a/backend/app/telegram/formatters.py
+++ b/backend/app/telegram/formatters.py
@@ -1,0 +1,80 @@
+from app.models.match import Match
+
+
+STATUS_LABELS = {
+    "upcoming": "Proximo",
+    "live": "EN VIVO",
+    "finished": "Finalizado",
+    "cancelled": "Cancelado",
+}
+
+
+def _ranking_str(ranking) -> str:
+    return f"#{ranking}" if ranking else "S/R"
+
+
+def format_match_summary(match: Match) -> str:
+    status_label = STATUS_LABELS.get(match.status.value, match.status.value)
+    date_str = match.date.strftime("%Y-%m-%d %H:%M")
+    home = match.player_home
+    away = match.player_away
+
+    lines = [
+        f"<b>{home.name}</b> vs <b>{away.name}</b>",
+        f"{match.tournament.name} | {status_label}",
+        f"{date_str}",
+    ]
+    if match.score:
+        lines.append(f"Score: {match.score}")
+    return "\n".join(lines)
+
+
+def format_match_detail(match: Match) -> str:
+    status_label = STATUS_LABELS.get(match.status.value, match.status.value)
+    date_str = match.date.strftime("%Y-%m-%d %H:%M")
+    home = match.player_home
+    away = match.player_away
+    t = match.tournament
+
+    lines = [
+        f"<b>Partido:</b> <code>{match.id}</code>",
+        "",
+        f"<b>{home.name}</b> ({home.country}, {_ranking_str(home.ranking)})",
+        "  vs",
+        f"<b>{away.name}</b> ({away.country}, {_ranking_str(away.ranking)})",
+        "",
+        f"<b>Torneo:</b> {t.name}",
+        f"<b>Superficie:</b> {t.surface.value} | {t.category}",
+        f"<b>Ubicacion:</b> {t.location}",
+        "",
+        f"<b>Fecha:</b> {date_str}",
+        f"<b>Estado:</b> {status_label}",
+    ]
+    if match.score:
+        lines.append(f"<b>Score:</b> {match.score}")
+    return "\n".join(lines)
+
+
+def format_match_list(matches: list[Match], total: int) -> str:
+    if not matches:
+        return "No se encontraron partidos."
+
+    parts = []
+    for i, match in enumerate(matches, 1):
+        parts.append(f"<b>{i}.</b> {format_match_summary(match)}")
+
+    header = f"<b>Partidos de tenis:</b> {total} encontrado(s)\n"
+    result = header + "\n\n".join(parts)
+
+    if total > len(matches):
+        result += f"\n\n<i>Mostrando {len(matches)} de {total}.</i>"
+    return result
+
+
+def format_health(status: str, version: str, data_mode: str) -> str:
+    return (
+        "<b>OddsEngine Status</b>\n"
+        f"Estado: {status}\n"
+        f"Version: {version}\n"
+        f"Modo de datos: {data_mode}"
+    )

--- a/backend/app/telegram/handlers.py
+++ b/backend/app/telegram/handlers.py
@@ -1,0 +1,83 @@
+import logging
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from app.services.match_service import get_match_service
+from app.core.config import get_settings
+from app.telegram.formatters import (
+    format_match_summary,
+    format_match_detail,
+    format_match_list,
+    format_health,
+)
+
+logger = logging.getLogger("oddsengine")
+
+WELCOME_TEXT = (
+    "<b>Bienvenido a OddsEngine Bot!</b>\n"
+    "Analizador de probabilidades de tenis.\n\n"
+    "<b>Comandos disponibles:</b>\n"
+    "/matches — Listar partidos de tenis\n"
+    "/matches &lt;status&gt; — Filtrar por estado (upcoming, live, finished)\n"
+    "/match &lt;id&gt; — Ver detalle de un partido\n"
+    "/health — Estado del servicio\n"
+    "/help — Mostrar esta ayuda"
+)
+
+MAX_MATCHES_DISPLAY = 10
+
+
+async def start_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await update.message.reply_text(WELCOME_TEXT, parse_mode="HTML")
+
+
+async def help_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await update.message.reply_text(WELCOME_TEXT, parse_mode="HTML")
+
+
+async def health_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    settings = get_settings()
+    text = format_health(status="ok", version="1.0.0", data_mode=settings.data_mode)
+    await update.message.reply_text(text, parse_mode="HTML")
+
+
+async def matches_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    status_filter = context.args[0] if context.args else None
+    service = get_match_service()
+
+    try:
+        matches = await service.get_matches(status=status_filter)
+    except Exception as e:
+        await update.message.reply_text(f"Error: {e}")
+        return
+
+    total = len(matches)
+    display = matches[:MAX_MATCHES_DISPLAY]
+    text = format_match_list(display, total)
+    await update.message.reply_text(text, parse_mode="HTML")
+
+
+async def match_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    if not context.args:
+        await update.message.reply_text(
+            "Uso: /match &lt;match_id&gt;\nEjemplo: /match match_001",
+            parse_mode="HTML",
+        )
+        return
+
+    match_id = context.args[0]
+    service = get_match_service()
+
+    try:
+        match = await service.get_match_by_id(match_id)
+    except Exception as e:
+        await update.message.reply_text(f"Error: {e}")
+        return
+
+    if match is None:
+        await update.message.reply_text(f"Partido '{match_id}' no encontrado.")
+        return
+
+    text = format_match_detail(match)
+    await update.message.reply_text(text, parse_mode="HTML")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,3 +19,5 @@ python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 email-validator==2.1.1
+# Telegram Bot
+python-telegram-bot==21.6

--- a/backend/tests/test_telegram_formatters.py
+++ b/backend/tests/test_telegram_formatters.py
@@ -1,0 +1,124 @@
+import pytest
+from datetime import datetime
+
+from app.models.match import Match, Player, Tournament, MatchStatus, Surface
+from app.telegram.formatters import (
+    format_match_summary,
+    format_match_detail,
+    format_match_list,
+    format_health,
+)
+
+
+def _make_match(
+    match_id="match_001",
+    home_name="Carlos Alcaraz",
+    away_name="Jannik Sinner",
+    status=MatchStatus.UPCOMING,
+    score=None,
+):
+    return Match(
+        id=match_id,
+        player_home=Player(id="p1", name=home_name, country="ESP", ranking=2),
+        player_away=Player(id="p2", name=away_name, country="ITA", ranking=1),
+        tournament=Tournament(
+            id="t1",
+            name="Roland Garros",
+            surface=Surface.CLAY,
+            category="Grand Slam",
+            location="Paris, France",
+        ),
+        date=datetime(2026, 5, 25, 14, 0),
+        status=status,
+        score=score,
+    )
+
+
+class TestFormatMatchSummary:
+    def test_contains_player_names(self):
+        result = format_match_summary(_make_match())
+        assert "Carlos Alcaraz" in result
+        assert "Jannik Sinner" in result
+
+    def test_contains_tournament(self):
+        result = format_match_summary(_make_match())
+        assert "Roland Garros" in result
+
+    def test_contains_status_label(self):
+        result = format_match_summary(_make_match(status=MatchStatus.LIVE))
+        assert "EN VIVO" in result
+
+    def test_contains_score_when_present(self):
+        result = format_match_summary(_make_match(score="6-3, 7-5"))
+        assert "6-3, 7-5" in result
+
+    def test_no_score_line_when_absent(self):
+        result = format_match_summary(_make_match(score=None))
+        assert "Score" not in result
+
+
+class TestFormatMatchDetail:
+    def test_contains_match_id(self):
+        result = format_match_detail(_make_match(match_id="match_042"))
+        assert "match_042" in result
+
+    def test_contains_player_details(self):
+        result = format_match_detail(_make_match())
+        assert "ESP" in result
+        assert "#2" in result
+        assert "ITA" in result
+        assert "#1" in result
+
+    def test_contains_tournament_info(self):
+        result = format_match_detail(_make_match())
+        assert "Roland Garros" in result
+        assert "clay" in result
+        assert "Grand Slam" in result
+        assert "Paris, France" in result
+
+    def test_contains_date(self):
+        result = format_match_detail(_make_match())
+        assert "2026-05-25 14:00" in result
+
+    def test_shows_score_for_finished(self):
+        result = format_match_detail(
+            _make_match(status=MatchStatus.FINISHED, score="6-3, 7-5")
+        )
+        assert "6-3, 7-5" in result
+        assert "Finalizado" in result
+
+    def test_no_ranking_shows_sr(self):
+        match = _make_match()
+        match.player_home.ranking = None
+        result = format_match_detail(match)
+        assert "S/R" in result
+
+
+class TestFormatMatchList:
+    def test_empty_list(self):
+        result = format_match_list([], 0)
+        assert "No se encontraron partidos" in result
+
+    def test_single_match(self):
+        matches = [_make_match()]
+        result = format_match_list(matches, 1)
+        assert "1 encontrado" in result
+        assert "Carlos Alcaraz" in result
+
+    def test_truncation_message(self):
+        matches = [_make_match(match_id=f"m_{i}") for i in range(5)]
+        result = format_match_list(matches, 20)
+        assert "Mostrando 5 de 20" in result
+
+    def test_no_truncation_message_when_all_shown(self):
+        matches = [_make_match()]
+        result = format_match_list(matches, 1)
+        assert "Mostrando" not in result
+
+
+class TestFormatHealth:
+    def test_contains_all_fields(self):
+        result = format_health(status="ok", version="1.0.0", data_mode="mock")
+        assert "ok" in result
+        assert "1.0.0" in result
+        assert "mock" in result

--- a/backend/tests/test_telegram_handlers.py
+++ b/backend/tests/test_telegram_handlers.py
@@ -1,0 +1,120 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _make_update_and_context(args=None):
+    update = MagicMock()
+    update.message = MagicMock()
+    update.message.reply_text = AsyncMock()
+    context = MagicMock()
+    context.args = args or []
+    return update, context
+
+
+@pytest.mark.anyio
+async def test_start_handler_sends_welcome():
+    from app.telegram.handlers import start_handler
+
+    update, context = _make_update_and_context()
+    await start_handler(update, context)
+
+    update.message.reply_text.assert_called_once()
+    text = update.message.reply_text.call_args[0][0]
+    assert "OddsEngine" in text
+    assert "/matches" in text
+
+
+@pytest.mark.anyio
+async def test_help_handler_sends_commands():
+    from app.telegram.handlers import help_handler
+
+    update, context = _make_update_and_context()
+    await help_handler(update, context)
+
+    update.message.reply_text.assert_called_once()
+    text = update.message.reply_text.call_args[0][0]
+    assert "/health" in text
+    assert "/match" in text
+
+
+@pytest.mark.anyio
+async def test_health_handler_returns_status():
+    from app.telegram.handlers import health_handler
+
+    update, context = _make_update_and_context()
+    await health_handler(update, context)
+
+    update.message.reply_text.assert_called_once()
+    text = update.message.reply_text.call_args[0][0]
+    assert "ok" in text
+    assert "1.0.0" in text
+
+
+@pytest.mark.anyio
+async def test_matches_handler_returns_list():
+    from app.telegram.handlers import matches_handler
+
+    update, context = _make_update_and_context()
+    await matches_handler(update, context)
+
+    update.message.reply_text.assert_called_once()
+    text = update.message.reply_text.call_args[0][0]
+    assert "Partidos de tenis" in text or "No se encontraron" in text
+
+
+@pytest.mark.anyio
+async def test_matches_handler_with_status_filter():
+    from app.telegram.handlers import matches_handler
+
+    update, context = _make_update_and_context(args=["upcoming"])
+    await matches_handler(update, context)
+
+    update.message.reply_text.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_matches_handler_invalid_status():
+    from app.telegram.handlers import matches_handler
+
+    update, context = _make_update_and_context(args=["invalid_status"])
+    await matches_handler(update, context)
+
+    update.message.reply_text.assert_called_once()
+    text = update.message.reply_text.call_args[0][0]
+    assert "Error" in text
+
+
+@pytest.mark.anyio
+async def test_match_handler_no_args_shows_usage():
+    from app.telegram.handlers import match_handler
+
+    update, context = _make_update_and_context(args=[])
+    await match_handler(update, context)
+
+    update.message.reply_text.assert_called_once()
+    text = update.message.reply_text.call_args[0][0]
+    assert "match_id" in text
+
+
+@pytest.mark.anyio
+async def test_match_handler_not_found():
+    from app.telegram.handlers import match_handler
+
+    update, context = _make_update_and_context(args=["nonexistent_999"])
+    await match_handler(update, context)
+
+    update.message.reply_text.assert_called_once()
+    text = update.message.reply_text.call_args[0][0]
+    assert "no encontrado" in text
+
+
+@pytest.mark.anyio
+async def test_match_handler_found():
+    from app.telegram.handlers import match_handler
+
+    update, context = _make_update_and_context(args=["match_001"])
+    await match_handler(update, context)
+
+    update.message.reply_text.assert_called_once()
+    text = update.message.reply_text.call_args[0][0]
+    assert "match_001" in text

--- a/docs/telegram_bot.md
+++ b/docs/telegram_bot.md
@@ -1,0 +1,77 @@
+# Telegram Bot — OddsEngine
+
+Bot de Telegram para consultar partidos de tenis y estado del servicio OddsEngine.
+
+## Comandos disponibles
+
+| Comando | Descripcion |
+|---------|-------------|
+| `/start` | Mensaje de bienvenida y lista de comandos |
+| `/help` | Muestra ayuda con todos los comandos |
+| `/health` | Estado del servicio (version, modo de datos) |
+| `/matches` | Lista los partidos de tenis disponibles |
+| `/matches <status>` | Filtra partidos por estado: `upcoming`, `live`, `finished` |
+| `/match <id>` | Detalle completo de un partido (ej: `/match match_001`) |
+
+## Crear el bot en Telegram
+
+1. Abrir Telegram y buscar `@BotFather`
+2. Enviar `/newbot`
+3. Seguir las instrucciones para darle nombre al bot
+4. BotFather devuelve un token como: `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`
+5. Guardar el token de forma segura
+
+## Ejecucion local
+
+1. Agregar el token en `backend/.env`:
+   ```
+   TELEGRAM_BOT_TOKEN=tu-token-aqui
+   ```
+
+2. Instalar dependencias (si no se ha hecho):
+   ```bash
+   cd backend
+   pip install -r requirements.txt
+   ```
+
+3. Iniciar el servidor:
+   ```bash
+   cd backend
+   uvicorn app.main:app --reload
+   ```
+
+4. En los logs debe aparecer: `Telegram Bot iniciado`
+
+5. Abrir Telegram, buscar el bot y enviar `/start`
+
+**Sin token**: Si `TELEGRAM_BOT_TOKEN` esta vacio o no existe, el bot no inicia y FastAPI funciona normalmente.
+
+## Ejecucion con Docker
+
+1. Agregar el token en el archivo `.env` de la raiz del proyecto:
+   ```
+   TELEGRAM_BOT_TOKEN=tu-token-aqui
+   ```
+
+2. Construir e iniciar:
+   ```bash
+   docker-compose up --build
+   ```
+
+3. El bot arranca dentro del contenedor `backend` usando polling (conexiones salientes HTTPS). No requiere puertos adicionales.
+
+## Notas tecnicas
+
+- El bot usa **polling** (no webhooks), por lo que no necesita IP publica ni configuracion de red especial.
+- El bot se integra en el ciclo de vida (`lifespan`) de FastAPI: arranca con el servidor y se detiene cuando se apaga.
+- Si el bot falla al iniciar (token invalido, sin internet), FastAPI sigue funcionando normalmente. El error se registra en los logs.
+- Dependencia: `python-telegram-bot==21.6` (async-native, v20+ API).
+
+## Tests
+
+Los tests no requieren token real de Telegram:
+
+```bash
+cd backend
+pytest tests/test_telegram_formatters.py tests/test_telegram_handlers.py -v
+```


### PR DESCRIPTION
## Resumen

Este PR agrega una primera versión del bot de Telegram para OddsEngine.

El bot permite consultar información pública del sistema sin afectar la autenticación, las combinadas privadas ni el historial de usuarios.

## Funcionalidades agregadas

- Comando `/start` para mensaje de bienvenida.
- Comando `/help` para listar comandos disponibles.
- Comando `/health` para consultar estado básico del sistema.
- Comando `/matches` para listar partidos disponibles.
- Comando `/match <match_id>` para consultar el detalle de un partido.

## Cambios técnicos

- Se agregó el paquete `backend/app/telegram/`.
- Se agregaron handlers y formatters para los mensajes del bot.
- Se agregó la variable `TELEGRAM_BOT_TOKEN` en `.env.example`.
- Se agregó la dependencia `python-telegram-bot`.
- El bot solo inicia si `TELEGRAM_BOT_TOKEN` está configurado.
- Se agregó documentación de uso en `docs/telegram_bot.md`.
- Se agregaron tests unitarios para formatters y handlers.

## Alcance

Este PR NO implementa todavía:

- Combinadas privadas por usuario.
- Historial asociado al usuario autenticado.
- Vinculación de cuenta web con Telegram.
- Notificaciones personalizadas.

Estas funcionalidades quedan para una fase posterior.

## Validaciones realizadas

Se ejecutaron los tests del backend correctamente:

```bash
./venv/Scripts/python.exe -m pytest tests/ -v --tb=short

