### PR TITLE
test(backend): mejorar cobertura de seguridad y autenticación

### DIFF
--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -2,7 +2,6 @@
 source = app
 omit =
     app/models/db_models.py
-    app/repositories/*
 
 [report]
 exclude_lines =

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -1,0 +1,129 @@
+"""
+Tests unitarios para app/services/auth_service.py
+
+Cubre: register_user, authenticate_user, get_user_by_email,
+get_user_by_id, clear.
+"""
+
+import pytest
+
+from app.services.auth_service import AuthService
+from app.core.exceptions import DuplicateException
+
+
+@pytest.fixture
+def auth_service():
+    """Instancia fresca de AuthService para cada test."""
+    return AuthService()
+
+
+class TestRegisterUser:
+
+    def test_success(self, auth_service):
+        user = auth_service.register_user("alice", "alice@test.com", "secret123")
+        assert user["username"] == "alice"
+        assert user["email"] == "alice@test.com"
+        assert user["is_active"] is True
+        assert "id" in user
+        assert "created_at" in user
+        assert "hashed_password" not in user
+
+    def test_duplicate_email_raises(self, auth_service):
+        auth_service.register_user("user1", "dup@test.com", "pass123456")
+        with pytest.raises(DuplicateException):
+            auth_service.register_user("user2", "dup@test.com", "pass123456")
+
+    def test_duplicate_email_case_insensitive(self, auth_service):
+        auth_service.register_user("user1", "Test@Example.COM", "pass123456")
+        with pytest.raises(DuplicateException):
+            auth_service.register_user("user2", "test@example.com", "pass123456")
+
+    def test_duplicate_username_raises(self, auth_service):
+        auth_service.register_user("sameuser", "a@test.com", "pass123456")
+        with pytest.raises(DuplicateException):
+            auth_service.register_user("sameuser", "b@test.com", "pass123456")
+
+    def test_duplicate_username_case_insensitive(self, auth_service):
+        auth_service.register_user("Alice", "a@test.com", "pass123456")
+        with pytest.raises(DuplicateException):
+            auth_service.register_user("alice", "b@test.com", "pass123456")
+
+    def test_multiple_users(self, auth_service):
+        u1 = auth_service.register_user("user1", "u1@test.com", "pass123456")
+        u2 = auth_service.register_user("user2", "u2@test.com", "pass123456")
+        assert u1["id"] != u2["id"]
+
+
+class TestAuthenticateUser:
+
+    def test_success(self, auth_service):
+        auth_service.register_user("bob", "bob@test.com", "mypassword")
+        result = auth_service.authenticate_user("bob@test.com", "mypassword")
+        assert result is not None
+        assert result["username"] == "bob"
+        assert result["email"] == "bob@test.com"
+        assert "hashed_password" not in result
+
+    def test_wrong_password(self, auth_service):
+        auth_service.register_user("bob", "bob@test.com", "mypassword")
+        result = auth_service.authenticate_user("bob@test.com", "wrongpass")
+        assert result is None
+
+    def test_nonexistent_email(self, auth_service):
+        result = auth_service.authenticate_user("nobody@test.com", "anypass")
+        assert result is None
+
+    def test_email_case_insensitive(self, auth_service):
+        auth_service.register_user("bob", "Bob@Test.COM", "mypassword")
+        result = auth_service.authenticate_user("bob@test.com", "mypassword")
+        assert result is not None
+        assert result["username"] == "bob"
+
+
+class TestGetUserByEmail:
+
+    def test_found(self, auth_service):
+        auth_service.register_user("carol", "carol@test.com", "pass123456")
+        user = auth_service.get_user_by_email("carol@test.com")
+        assert user is not None
+        assert user["username"] == "carol"
+        assert "hashed_password" not in user
+
+    def test_not_found(self, auth_service):
+        result = auth_service.get_user_by_email("noone@test.com")
+        assert result is None
+
+    def test_case_insensitive(self, auth_service):
+        auth_service.register_user("carol", "Carol@Test.COM", "pass123456")
+        user = auth_service.get_user_by_email("carol@test.com")
+        assert user is not None
+
+
+class TestGetUserById:
+
+    def test_found(self, auth_service):
+        registered = auth_service.register_user("dave", "dave@test.com", "pass123456")
+        user = auth_service.get_user_by_id(registered["id"])
+        assert user is not None
+        assert user["username"] == "dave"
+        assert "hashed_password" not in user
+
+    def test_not_found(self, auth_service):
+        result = auth_service.get_user_by_id("user_nonexistent")
+        assert result is None
+
+
+class TestClear:
+
+    def test_removes_all_users(self, auth_service):
+        auth_service.register_user("u1", "u1@test.com", "pass123456")
+        auth_service.register_user("u2", "u2@test.com", "pass123456")
+        auth_service.clear()
+        assert auth_service.get_user_by_email("u1@test.com") is None
+        assert auth_service.get_user_by_email("u2@test.com") is None
+
+    def test_allows_reregistration_after_clear(self, auth_service):
+        auth_service.register_user("u1", "u1@test.com", "pass123456")
+        auth_service.clear()
+        user = auth_service.register_user("u1", "u1@test.com", "pass123456")
+        assert user["username"] == "u1"

--- a/backend/tests/test_combinations.py
+++ b/backend/tests/test_combinations.py
@@ -136,7 +136,6 @@ async def test_get_nonexistent_combination(client: AsyncClient):
 
 
 @pytest.mark.anyio
-@pytest.mark.skip(reason="pending: test isolation — storage not reset between tests")
 async def test_list_combinations(client: AsyncClient):
     """Listar combinadas retorna todas las activas."""
     await create_combination(client)

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,168 @@
+"""
+Tests unitarios para app/core/security.py
+
+Cubre: hash_password, verify_password, create_access_token,
+decode_access_token, get_current_user.
+"""
+
+import pytest
+from datetime import timedelta
+from unittest.mock import patch, MagicMock
+
+from app.core.security import (
+    hash_password,
+    verify_password,
+    create_access_token,
+    decode_access_token,
+    get_current_user,
+)
+
+
+class TestHashPassword:
+
+    def test_returns_string(self):
+        result = hash_password("mypassword")
+        assert isinstance(result, str)
+        assert result != "mypassword"
+
+    def test_different_hash_each_time(self):
+        h1 = hash_password("samepassword")
+        h2 = hash_password("samepassword")
+        assert h1 != h2
+
+
+class TestVerifyPassword:
+
+    def test_correct_password(self):
+        hashed = hash_password("secret123")
+        assert verify_password("secret123", hashed) is True
+
+    def test_incorrect_password(self):
+        hashed = hash_password("secret123")
+        assert verify_password("wrongpassword", hashed) is False
+
+
+class TestCreateAccessToken:
+
+    def test_returns_string(self):
+        token = create_access_token(data={"sub": "user_123"})
+        assert isinstance(token, str)
+        assert len(token) > 0
+
+    def test_custom_expiry(self):
+        token = create_access_token(
+            data={"sub": "user_123"},
+            expires_delta=timedelta(minutes=5),
+        )
+        payload = decode_access_token(token)
+        assert payload is not None
+        assert payload["sub"] == "user_123"
+
+    def test_payload_contains_sub(self):
+        token = create_access_token(data={"sub": "user_abc"})
+        payload = decode_access_token(token)
+        assert payload["sub"] == "user_abc"
+
+    def test_payload_contains_exp(self):
+        token = create_access_token(data={"sub": "user_123"})
+        payload = decode_access_token(token)
+        assert "exp" in payload
+
+
+class TestDecodeAccessToken:
+
+    def test_valid_token(self):
+        token = create_access_token(data={"sub": "user_xyz", "role": "admin"})
+        payload = decode_access_token(token)
+        assert payload is not None
+        assert payload["sub"] == "user_xyz"
+        assert payload["role"] == "admin"
+
+    def test_invalid_token(self):
+        result = decode_access_token("invalid.token.string")
+        assert result is None
+
+    def test_tampered_token(self):
+        token = create_access_token(data={"sub": "user_123"})
+        tampered = token[:-5] + "XXXXX"
+        result = decode_access_token(tampered)
+        assert result is None
+
+    def test_expired_token(self):
+        token = create_access_token(
+            data={"sub": "user_123"},
+            expires_delta=timedelta(seconds=-1),
+        )
+        result = decode_access_token(token)
+        assert result is None
+
+
+class TestGetCurrentUser:
+
+    @pytest.mark.anyio
+    async def test_valid_token(self):
+        from app.services.auth_service import get_auth_service
+
+        service = get_auth_service()
+        user = service.register_user("secuser", "sec@test.com", "password123")
+
+        token = create_access_token(data={"sub": user["id"]})
+        credentials = MagicMock()
+        credentials.credentials = token
+
+        result = await get_current_user(credentials)
+        assert result["id"] == user["id"]
+        assert result["username"] == "secuser"
+
+    @pytest.mark.anyio
+    async def test_invalid_token_raises_401(self):
+        from fastapi import HTTPException
+
+        credentials = MagicMock()
+        credentials.credentials = "bad.token.here"
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.anyio
+    async def test_token_without_sub_raises_401(self):
+        from fastapi import HTTPException
+
+        token = create_access_token(data={"role": "admin"})
+        credentials = MagicMock()
+        credentials.credentials = token
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.anyio
+    async def test_user_not_found_raises_401(self):
+        from fastapi import HTTPException
+
+        token = create_access_token(data={"sub": "nonexistent_user_id"})
+        credentials = MagicMock()
+        credentials.credentials = token
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.anyio
+    async def test_inactive_user_raises_403(self):
+        from fastapi import HTTPException
+        from app.services.auth_service import get_auth_service
+
+        service = get_auth_service()
+        user = service.register_user("inactive", "inactive@test.com", "pass123456")
+
+        service._users[service._email_index["inactive@test.com"]]["is_active"] = False
+
+        token = create_access_token(data={"sub": user["id"]})
+        credentials = MagicMock()
+        credentials.credentials = token
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials)
+        assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Resumen

Este PR mejora la cobertura del backend para apoyar el cumplimiento del Quality Gate de SonarCloud.

## Cambios realizados

- Se ajustó `.coveragerc` para no excluir los repositorios de la medición de cobertura.
- Se habilitó el test de listado de combinadas.
- Se agregaron tests unitarios para `core/security.py`.
- Se agregaron tests unitarios para `services/auth_service.py`.

## Validaciones realizadas

Se ejecutaron los tests del backend con coverage:

```bash
./venv/Scripts/python.exe -m pytest tests/ -v --tb=short --cov=app --cov-report=term-missing --cov-branch --cov-report=xml:coverage.xml

