### PR TITLE
fix(security): remover env versionado y corregir parseo de metricas

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-DATA_MODE=mock
-DEBUG=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 frontend/node_modules/
+.env
+.coverage
+coverage.xml
+backend/.coverage
+backend/coverage.xml

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -1,8 +1,58 @@
-import re
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 from prometheus_fastapi_instrumentator import Instrumentator
 from prometheus_client import generate_latest, REGISTRY
+
+_METRIC_PREFIXES = (
+    "http_request_duration_seconds_sum",
+    "http_request_duration_seconds_count",
+)
+
+
+def _parse_labels(labels_str: str) -> dict[str, str]:
+    """Parsea labels Prometheus 'key="value",key2="value2"' sin regex."""
+    labels: dict[str, str] = {}
+    for pair in labels_str.split(","):
+        if "=" not in pair:
+            continue
+        key, _, quoted_val = pair.partition("=")
+        key = key.strip()
+        val = quoted_val.strip().strip('"')
+        if key:
+            labels[key] = val
+    return labels
+
+
+def _parse_metric_line(linea: str):
+    """
+    Parsea una línea de métrica Prometheus sin regex.
+
+    Retorna (nombre_metrica, labels_dict, valor_float) o None.
+    """
+    brace_open = linea.find("{")
+    brace_close = linea.find("}", brace_open + 1) if brace_open != -1 else -1
+
+    if brace_open == -1 or brace_close == -1:
+        return None
+
+    metric_name = linea[:brace_open]
+    if metric_name not in _METRIC_PREFIXES:
+        return None
+
+    labels_str = linea[brace_open + 1:brace_close]
+    valor_str = linea[brace_close + 1:].strip()
+
+    if not valor_str:
+        return None
+
+    try:
+        valor = float(valor_str)
+    except ValueError:
+        return None
+
+    labels = _parse_labels(labels_str)
+    return metric_name, labels, valor
+
 
 def setup_metrics(app: FastAPI):
 
@@ -18,26 +68,22 @@ def setup_metrics(app: FastAPI):
         sumas_latencia = {}
         conteos_peticiones = {}
 
-        pattern = re.compile(r'(http_request_duration_seconds_(?:sum|count))\{([^}]+)\}\s+([\d.]+)')
-        label_pattern = re.compile(r'(\w+)="([^"]+)"')
-
         for linea in lineas:
-            match = pattern.search(linea)
-            if match:
-                metrica, labels_str, valor_str = match.groups()
-                valor = float(valor_str)
-                labels = dict(label_pattern.findall(labels_str))
-                
-                handler = labels.get("handler", "unknown")
-                method = labels.get("method", "unknown")
-                status = labels.get("status", "unknown")
-                    
-                key = (method, handler, status)
-                
-                if metrica == "http_request_duration_seconds_sum":
-                    sumas_latencia[key] = valor
-                elif metrica == "http_request_duration_seconds_count":
-                    conteos_peticiones[key] = int(valor)
+            parsed = _parse_metric_line(linea)
+            if parsed is None:
+                continue
+
+            metrica, labels, valor = parsed
+            handler = labels.get("handler", "unknown")
+            method = labels.get("method", "unknown")
+            status = labels.get("status", "unknown")
+
+            key = (method, handler, status)
+
+            if metrica == "http_request_duration_seconds_sum":
+                sumas_latencia[key] = valor
+            elif metrica == "http_request_duration_seconds_count":
+                conteos_peticiones[key] = int(valor)
 
         datos_consolidados = []
         for key in conteos_peticiones:

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,0 +1,111 @@
+"""
+Tests unitarios para app/core/metrics.py
+
+Cubre: _parse_labels, _parse_metric_line (parseo sin regex).
+No requiere red, Docker ni PostgreSQL.
+"""
+
+import pytest
+
+from app.core.metrics import _parse_labels, _parse_metric_line
+
+
+class TestParseLabels:
+
+    def test_single_label(self):
+        result = _parse_labels('handler="/health"')
+        assert result == {"handler": "/health"}
+
+    def test_multiple_labels(self):
+        result = _parse_labels('method="GET",handler="/api/matches",status="200"')
+        assert result == {
+            "method": "GET",
+            "handler": "/api/matches",
+            "status": "200",
+        }
+
+    def test_empty_string(self):
+        result = _parse_labels("")
+        assert result == {}
+
+    def test_label_with_spaces(self):
+        result = _parse_labels(' method="POST" , handler="/api/auth/login" ')
+        assert result == {"method": "POST", "handler": "/api/auth/login"}
+
+    def test_label_with_empty_value(self):
+        result = _parse_labels('handler=""')
+        assert result == {"handler": ""}
+
+    def test_malformed_no_equals(self):
+        result = _parse_labels("noequalshere")
+        assert result == {}
+
+
+class TestParseMetricLine:
+
+    def test_sum_metric(self):
+        line = 'http_request_duration_seconds_sum{method="GET",handler="/health",status="200"} 0.123'
+        result = _parse_metric_line(line)
+        assert result is not None
+        metric, labels, value = result
+        assert metric == "http_request_duration_seconds_sum"
+        assert labels["method"] == "GET"
+        assert labels["handler"] == "/health"
+        assert labels["status"] == "200"
+        assert value == pytest.approx(0.123)
+
+    def test_count_metric(self):
+        line = 'http_request_duration_seconds_count{method="POST",handler="/api/auth/register",status="201"} 5.0'
+        result = _parse_metric_line(line)
+        assert result is not None
+        metric, labels, value = result
+        assert metric == "http_request_duration_seconds_count"
+        assert labels["method"] == "POST"
+        assert labels["handler"] == "/api/auth/register"
+        assert labels["status"] == "201"
+        assert value == 5.0
+
+    def test_ignores_unrelated_metric(self):
+        line = 'python_gc_objects_collected_total{generation="0"} 1234.0'
+        result = _parse_metric_line(line)
+        assert result is None
+
+    def test_ignores_comment_lines(self):
+        line = "# HELP http_request_duration_seconds_sum Total duration"
+        result = _parse_metric_line(line)
+        assert result is None
+
+    def test_ignores_type_lines(self):
+        line = "# TYPE http_request_duration_seconds_sum summary"
+        result = _parse_metric_line(line)
+        assert result is None
+
+    def test_ignores_line_without_braces(self):
+        line = "http_request_duration_seconds_sum 0.5"
+        result = _parse_metric_line(line)
+        assert result is None
+
+    def test_ignores_line_with_no_value(self):
+        line = 'http_request_duration_seconds_sum{method="GET"}'
+        result = _parse_metric_line(line)
+        assert result is None
+
+    def test_ignores_line_with_invalid_value(self):
+        line = 'http_request_duration_seconds_sum{method="GET"} notanumber'
+        result = _parse_metric_line(line)
+        assert result is None
+
+    def test_large_value(self):
+        line = 'http_request_duration_seconds_sum{method="GET",handler="/api/matches",status="200"} 12345.6789'
+        result = _parse_metric_line(line)
+        assert result is not None
+        _, _, value = result
+        assert value == pytest.approx(12345.6789)
+
+    def test_no_backtracking_on_adversarial_input(self):
+        adversarial = 'http_request_duration_seconds_sum{' + 'a="b",' * 1000 + '} 1.0'
+        result = _parse_metric_line(adversarial)
+        assert result is not None
+        _, labels, value = result
+        assert labels.get("a") == "b"
+        assert value == 1.0


### PR DESCRIPTION
## Resumen

Este PR corrige pendientes de SonarCloud relacionados con seguridad y limpieza de archivos sensibles.

## Cambios realizados

- Se removió `.env` del control de versiones.
- Se agregó `.env` al `.gitignore`.
- Se agregaron reglas para ignorar archivos de coverage.
- Se corrigió el Security Hotspot en `backend/app/core/metrics.py`.
- Se eliminó el uso de regex vulnerable a backtracking.
- Se reemplazó el parseo por lógica basada en `str.find`, `split` y `partition`.
- Se agregaron tests unitarios para métricas.

## Validaciones realizadas

Se ejecutaron todos los tests del backend con coverage:

```bash
./venv/Scripts/python.exe -m pytest tests/ -v --tb=short --cov=app --cov-report=term-missing --cov-branch --cov-report=xml:coverage.xml
