### PR TITLE
fix(security): evitar logs con datos controlados por usuario

### DIFF
--- a/backend/app/routes/combinations.py
+++ b/backend/app/routes/combinations.py
@@ -36,7 +36,7 @@ async def create_combination():
     """
     service = get_combination_service()
     combination = await service.create_combination()
-    logger.info(f"POST /combinations — creada: {combination.id}")
+    logger.info("POST /combinations — combinada creada")
 
     return CombinationResponse(
         id=combination.id,
@@ -53,7 +53,7 @@ async def list_combinations():
     """Lista todas las combinadas activas."""
     service = get_combination_service()
     combinations = await service.list_combinations()
-    logger.info(f"GET /combinations — total: {len(combinations)}")
+    logger.info("GET /combinations — listado solicitado")
 
     return [
         CombinationSummary(
@@ -75,7 +75,7 @@ async def get_combination(combination_id: str):
     """
     service = get_combination_service()
     combination = await service.get_combination(combination_id)
-    logger.info(f"GET /combinations/{combination_id}")
+    logger.info("GET /combinations — consulta por ID")
 
     return CombinationResponse(
         id=combination.id,
@@ -91,7 +91,7 @@ async def delete_combination(combination_id: str):
     """Elimina una combinada completa."""
     service = get_combination_service()
     await service.delete_combination(combination_id)
-    logger.info(f"DELETE /combinations/{combination_id}")
+    logger.info("DELETE /combinations — combinada eliminada")
 
     return {"message": f"Combinada '{combination_id}' eliminada correctamente"}
 
@@ -114,10 +114,7 @@ async def add_match_to_combination(
         combination_id=combination_id,
         match_id=request.match_id,
     )
-    logger.info(
-        f"POST /combinations/{combination_id}/matches — "
-        f"agregado: {request.match_id}"
-    )
+    logger.info("POST /combinations/matches — partido agregado")
     return result
 
 
@@ -138,9 +135,7 @@ async def remove_match_from_combination(combination_id: str, match_id: str):
         combination_id=combination_id,
         match_id=match_id,
     )
-    logger.info(
-        f"DELETE /combinations/{combination_id}/matches/{match_id}"
-    )
+    logger.info("DELETE /combinations/matches — partido eliminado")
     return result
 
 
@@ -154,5 +149,5 @@ async def save_combination(combination_id: str):
     """
     service = get_combination_service()
     result = await service.save_combination_to_db(combination_id)
-    logger.info(f"POST /combinations/{combination_id}/save — guardada en BD")
+    logger.info("POST /combinations/save — combinada guardada en BD")
     return result

--- a/backend/app/routes/matches.py
+++ b/backend/app/routes/matches.py
@@ -40,7 +40,7 @@ async def list_matches(
     if limit < 1:
         raise ValidationException("El parámetro 'limit' debe ser >= 1")
 
-    logger.info(f"GET /matches — status={status}, tournament={tournament}, page={page}, limit={limit}")
+    logger.info("GET /matches — listado con filtros solicitado")
     service = get_match_service()
     matches = await service.get_matches(status=status, tournament=tournament)
 
@@ -49,14 +49,14 @@ async def list_matches(
     end = start + limit
     paginated = matches[start:end]
 
-    logger.info(f"Retornando {len(paginated)} partidos (página {page}, total {len(matches)})")
+    logger.info("GET /matches — respuesta paginada enviada")
     return paginated
 
 
 @router.get("/matches/{match_id}", response_model=Match)
 async def get_match(match_id: str):
     """Obtiene un partido específico por su ID."""
-    logger.info(f"GET /matches/{match_id}")
+    logger.info("GET /matches — consulta por ID")
     service = get_match_service()
     match = await service.get_match_by_id(match_id)
     if not match:

--- a/backend/app/services/combination_service.py
+++ b/backend/app/services/combination_service.py
@@ -41,7 +41,7 @@ class CombinationService:
         """Crea una nueva combinada vacía."""
         combination = Combination()
         self._storage.save_combination(combination)
-        logger.info(f"Combinada creada: {combination.id}")
+        logger.info("Combinada creada")
         return combination
 
     async def get_combination(self, combination_id: str) -> Combination:
@@ -91,10 +91,7 @@ class CombinationService:
         combination.updated_at = datetime.now(timezone.utc)
         self._storage.save_combination(combination)
 
-        logger.info(
-            f"Partido {match_id} agregado a combinada {combination_id} "
-            f"(total: {combination.total_selections})"
-        )
+        logger.info("Partido agregado a combinada")
 
         return CombinationResponse(
             id=combination.id,
@@ -132,10 +129,7 @@ class CombinationService:
         combination.updated_at = datetime.now(timezone.utc)
         self._storage.save_combination(combination)
 
-        logger.info(
-            f"Partido {match_id} eliminado de combinada {combination_id} "
-            f"(total: {combination.total_selections})"
-        )
+        logger.info("Partido eliminado de combinada")
 
         return CombinationResponse(
             id=combination.id,
@@ -152,7 +146,7 @@ class CombinationService:
         await self.get_combination(combination_id)
 
         deleted = self._storage.delete_combination(combination_id)
-        logger.info(f"Combinada {combination_id} eliminada")
+        logger.info("Combinada eliminada")
         return deleted
 
     async def list_combinations(self) -> list[Combination]:
@@ -176,10 +170,7 @@ class CombinationService:
         if settings.data_mode != "database":
             # En modo memoria no hay BD real — devolver confirmación igualmente
             # para no romper el flujo en desarrollo local sin PostgreSQL.
-            logger.warning(
-                f"save_combination_to_db llamado en modo '{settings.data_mode}': "
-                "sin persistencia real en BD."
-            )
+            logger.warning("save_combination_to_db llamado sin persistencia real en BD")
             return {
                 "message": (
                     f"Combinada '{combination_id}' guardada "
@@ -238,10 +229,7 @@ class CombinationService:
                     )
                     session.add(db_sel)
 
-        logger.info(
-            f"Combinada {combination_id} persistida en BD "
-            f"({combination.total_selections} selecciones)"
-        )
+        logger.info("Combinada persistida en BD")
 
         return {
             "message": f"Combinada guardada correctamente con {combination.total_selections} selecciones.",


### PR DESCRIPTION
## Resumen

Este PR corrige los issues de seguridad reportados por SonarCloud relacionados con logging de datos controlados por el usuario.

## Cambios realizados

- Se actualizaron logs en `backend/app/routes/combinations.py` para evitar interpolar IDs, payloads o datos provenientes del request.
- Se actualizaron logs en `backend/app/routes/matches.py` para evitar registrar filtros, parámetros de paginación o `match_id` enviados por el usuario.
- Se actualizaron logs en `backend/app/services/combination_service.py` para evitar registrar `combination_id`, `match_id`, número de selecciones o valores configurables en mensajes dinámicos.
- Se reemplazaron mensajes con `f-string` por mensajes estáticos cuando podían incluir datos controlados por usuario.

## Validaciones realizadas

Se ejecutaron los tests del backend con coverage:

```bash
./venv/Scripts/python.exe -m pytest tests/ -v --tb=short --cov=app --cov-report=term-missing --cov-branch --cov-report=xml:coverage.xml

