### PR TITLE
refactor(backend): usar Annotated y limpiar import no usado

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -11,7 +11,7 @@ Funciones:
 
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Annotated, Optional
 
 from jose import JWTError, jwt
 from passlib.context import CryptContext
@@ -83,7 +83,7 @@ def decode_access_token(token: str) -> Optional[dict]:
 
 
 async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(bearer_scheme)],
 ):
     """
     Dependencia de FastAPI — extrae y valida el usuario del token Bearer.

--- a/backend/app/providers/mock_stats_provider.py
+++ b/backend/app/providers/mock_stats_provider.py
@@ -5,7 +5,6 @@ Datos ficticios pero coherentes con el ranking real ATP.
 Se usa para desarrollo sin depender de PostgreSQL o API externa.
 """
 
-import json
 from typing import Optional
 
 from app.models.stats import PlayerStats, HeadToHead, HeadToHeadMatch, MatchStats

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -8,6 +8,8 @@ Endpoints:
 """
 
 import logging
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 
 from app.models.user import UserCreate, UserLogin, UserResponse, TokenResponse
@@ -69,7 +71,7 @@ async def login(data: UserLogin):
 
 
 @router.get("/me", response_model=UserResponse)
-async def get_me(current_user: dict = Depends(get_current_user)):
+async def get_me(current_user: Annotated[dict, Depends(get_current_user)]):
     """
     Retorna los datos del usuario autenticado.
 

--- a/backend/app/routes/matches.py
+++ b/backend/app/routes/matches.py
@@ -7,8 +7,9 @@ Endpoints:
 """
 
 import logging
+from typing import Annotated, Optional
+
 from fastapi import APIRouter, Query
-from typing import Optional
 
 from app.models.match import Match, MatchStatus
 from app.services.match_service import get_match_service
@@ -21,10 +22,10 @@ router = APIRouter(tags=["matches"])
 
 @router.get("/matches", response_model=list[Match])
 async def list_matches(
-    status: Optional[MatchStatus] = Query(None, description="Filtrar por estado del partido"),
-    tournament: Optional[str] = Query(None, description="Filtrar por nombre de torneo"),
-    page: int = Query(1, description="Número de página (desde 1)"),
-    limit: int = Query(10, description="Partidos por página"),
+    status: Annotated[Optional[MatchStatus], Query(description="Filtrar por estado del partido")] = None,
+    tournament: Annotated[Optional[str], Query(description="Filtrar por nombre de torneo")] = None,
+    page: Annotated[int, Query(description="Número de página (desde 1)")] = 1,
+    limit: Annotated[int, Query(description="Partidos por página")] = 10,
 ):
     """
     Lista los partidos de tenis disponibles.


### PR DESCRIPTION
## Resumen

Este PR aplica una limpieza menor de Maintainability reportada por SonarCloud en el backend.

## Cambios realizados

- Se eliminó un import no usado en `mock_stats_provider.py`.
- Se migraron parámetros de FastAPI a `Annotated` en:
  - `backend/app/routes/matches.py`
  - `backend/app/routes/auth.py`
  - `backend/app/core/security.py`

## Issues abordados

- Import no utilizado.
- Uso recomendado de `Annotated` para dependencias y parámetros de FastAPI.

## Validaciones realizadas

Se ejecutaron los tests del backend:

```bash
./venv/Scripts/python.exe -m pytest tests/ -v --tb=short

