### PR TITLE
refactor(backend): usar lazy logging

### DIFF
--- a/backend/app/core/error_handlers.py
+++ b/backend/app/core/error_handlers.py
@@ -44,10 +44,8 @@ def register_error_handlers(app: FastAPI) -> None:
     async def oddsengine_exception_handler(request: Request, exc: OddsEngineException):
         """Maneja todas las excepciones del dominio OddsEngine."""
         logger.error(
-            f"OddsEngineException: {exc.message} | "
-            f"Status: {exc.status_code} | "
-            f"Path: {request.url.path} | "
-            f"Method: {request.method}"
+            "OddsEngineException: %s | Status: %s | Path: %s | Method: %s",
+            exc.message, exc.status_code, request.url.path, request.method,
         )
         return JSONResponse(
             status_code=exc.status_code,
@@ -62,9 +60,8 @@ def register_error_handlers(app: FastAPI) -> None:
     async def external_api_exception_handler(request: Request, exc: ExternalAPIException):
         """Maneja errores de comunicación con APIs externas."""
         logger.error(
-            f"ExternalAPIException: {exc.message} | "
-            f"Source: {exc.source} | "
-            f"Path: {request.url.path}"
+            "ExternalAPIException: %s | Source: %s | Path: %s",
+            exc.message, exc.source, request.url.path,
         )
         return JSONResponse(
             status_code=exc.status_code,
@@ -80,9 +77,8 @@ def register_error_handlers(app: FastAPI) -> None:
     async def api_timeout_exception_handler(request: Request, exc: APITimeoutException):
         """Maneja timeouts de APIs externas."""
         logger.warning(
-            f"APITimeoutException: {exc.message} | "
-            f"Source: {exc.source} | "
-            f"Path: {request.url.path}"
+            "APITimeoutException: %s | Source: %s | Path: %s",
+            exc.message, exc.source, request.url.path,
         )
         return JSONResponse(
             status_code=exc.status_code,
@@ -98,8 +94,8 @@ def register_error_handlers(app: FastAPI) -> None:
     async def validation_exception_handler(request: Request, exc: RequestValidationError):
         """Maneja errores de validación de FastAPI/Pydantic."""
         logger.warning(
-            f"ValidationError: {exc.errors()} | "
-            f"Path: {request.url.path}"
+            "ValidationError: %s | Path: %s",
+            exc.errors(), request.url.path,
         )
         return JSONResponse(
             status_code=422,
@@ -115,9 +111,8 @@ def register_error_handlers(app: FastAPI) -> None:
     async def generic_exception_handler(request: Request, exc: Exception):
         """Captura cualquier excepción no manejada para evitar fallos críticos."""
         logger.critical(
-            f"Unhandled Exception: {type(exc).__name__}: {str(exc)} | "
-            f"Path: {request.url.path} | "
-            f"Method: {request.method}",
+            "Unhandled Exception: %s: %s | Path: %s | Method: %s",
+            type(exc).__name__, exc, request.url.path, request.method,
             exc_info=True,
         )
         return JSONResponse(

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -53,4 +53,4 @@ def setup_logging(log_level: str = "INFO", log_file: str = "oddsengine.log") -> 
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
-    logger.info(f"Logging configurado — nivel: {log_level}")
+    logger.info("Logging configurado — nivel: %s", log_level)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -38,7 +38,7 @@ async def lifespan(app: FastAPI):
             logger.exception("Error iniciando Telegram Bot")
             bot_app = None
 
-    logger.info(f"OddsEngine v1.0.0 iniciado — modo: {settings.data_mode}")
+    logger.info("OddsEngine v1.0.0 iniciado — modo: %s", settings.data_mode)
     yield
 
     if bot_app:
@@ -76,7 +76,7 @@ async def log_requests(request: Request, call_next):
     start = time.time()
     response = await call_next(request)
     duration = round((time.time() - start) * 1000, 1)
-    logger.info(f"{request.method} {request.url.path} → {response.status_code} ({duration}ms)")
+    logger.info("%s %s → %s (%sms)", request.method, request.url.path, response.status_code, duration)
     return response
 
 

--- a/backend/app/repositories/matches_repository.py
+++ b/backend/app/repositories/matches_repository.py
@@ -85,10 +85,10 @@ class MatchesRepository:
                 db_match = MatchDB(**match_data)
                 self.db.add(db_match)
             await self.db.commit()
-            logger.info(f"Insertados {len(matches)} partidos en PostgreSQL")
+            logger.info("Insertados %s partidos en PostgreSQL", len(matches))
         except SQLAlchemyError as e:
             await self.db.rollback()
-            logger.error(f"Error al insertar partidos: {e}")
+            logger.error("Error al insertar partidos: %s", e)
             raise
 
     async def delete_all(self):
@@ -104,7 +104,7 @@ class MatchesRepository:
             logger.info("Todos los partidos eliminados de PostgreSQL")
         except SQLAlchemyError as e:
             await self.db.rollback()
-            logger.error(f"Error al eliminar partidos: {e}")
+            logger.error("Error al eliminar partidos: %s", e)
             raise
 
     def _to_pydantic(self, row: MatchDB) -> Match:

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -40,7 +40,7 @@ async def register(data: UserCreate):
     )
 
     token = create_access_token(data={"sub": user["id"]})
-    logger.info(f"POST /auth/register — usuario: {user['username']}")
+    logger.info("POST /auth/register — usuario registrado")
 
     return TokenResponse(
         access_token=token,
@@ -62,7 +62,7 @@ async def login(data: UserLogin):
         raise ValidationException(message="Email o contraseña incorrectos")
 
     token = create_access_token(data={"sub": user["id"]})
-    logger.info(f"POST /auth/login — usuario: {user['username']}")
+    logger.info("POST /auth/login — login exitoso")
 
     return TokenResponse(
         access_token=token,
@@ -77,5 +77,5 @@ async def get_me(current_user: Annotated[dict, Depends(get_current_user)]):
 
     Requiere token Bearer en el header Authorization.
     """
-    logger.info(f"GET /auth/me — usuario: {current_user['username']}")
+    logger.info("GET /auth/me — consulta de usuario autenticado")
     return UserResponse(**current_user)

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -62,7 +62,7 @@ class AuthService:
         self._users[user_id] = user
         self._email_index[email_lower] = user_id
 
-        logger.info(f"Usuario registrado: {username} ({email_lower})")
+        logger.info("Usuario registrado correctamente")
         return self._to_public(user)
 
     def authenticate_user(self, email: str, password: str) -> Optional[dict]:
@@ -84,7 +84,7 @@ class AuthService:
         if not verify_password(password, user["hashed_password"]):
             return None
 
-        logger.info(f"Login exitoso: {user['username']} ({email_lower})")
+        logger.info("Login exitoso")
         return self._to_public(user)
 
     def get_user_by_email(self, email: str) -> Optional[dict]:

--- a/backend/app/services/match_service.py
+++ b/backend/app/services/match_service.py
@@ -43,7 +43,7 @@ class MatchService:
 
         matches.sort(key=lambda m: m.date)
 
-        logger.info(f"Retornando {len(matches)} partidos")
+        logger.info("Retornando %s partidos", len(matches))
         return matches
 
     async def get_match_by_id(self, match_id: str) -> Optional[Match]:


### PR DESCRIPTION
## Resumen

Este PR aplica limpieza de Maintainability reportada por SonarCloud en el backend.

## Cambios realizados

- Se eliminó un import no usado en `mock_stats_provider.py`.
- Se migraron parámetros y dependencias de FastAPI a `Annotated`.
- Se reemplazaron logs con `f-string` por lazy logging.
- Se dejaron logs estáticos cuando podían incluir datos controlados por el usuario.

## Archivos principales modificados

- `backend/app/providers/mock_stats_provider.py`
- `backend/app/routes/matches.py`
- `backend/app/routes/auth.py`
- `backend/app/core/security.py`
- `backend/app/main.py`
- `backend/app/core/error_handlers.py`
- `backend/app/services/auth_service.py`
- `backend/app/services/match_service.py`
- `backend/app/core/logging_config.py`
- `backend/app/repositories/matches_repository.py`

## Validaciones realizadas

Se ejecutaron los tests del backend:

```bash
./venv/Scripts/python.exe -m pytest tests/ -v --tb=short

