### PR TITLE
refactor(backend): limpiar issues simples de maintainability

### DIFF
--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -7,6 +7,7 @@ Los logs se escriben a consola con formato legible y a archivo para persistencia
 
 import logging
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -35,9 +36,6 @@ def setup_logging(log_level: str = "INFO", log_file: str = "oddsengine.log") -> 
     console_handler.setFormatter(console_format)
 
     # Handler de archivo
-    log_path = Path("logs")
-    # Fix: Usar /tmp que siempre tiene permisos de escritura
-    import tempfile
     log_path = Path(tempfile.gettempdir()) / "oddsengine_logs"
     log_path.mkdir(exist_ok=True, parents=True)
     file_handler = logging.FileHandler(log_path / log_file, encoding="utf-8")

--- a/backend/app/repositories/matches_repository.py
+++ b/backend/app/repositories/matches_repository.py
@@ -86,9 +86,9 @@ class MatchesRepository:
                 self.db.add(db_match)
             await self.db.commit()
             logger.info("Insertados %s partidos en PostgreSQL", len(matches))
-        except SQLAlchemyError as e:
+        except SQLAlchemyError:
             await self.db.rollback()
-            logger.error("Error al insertar partidos: %s", e)
+            logger.exception("Error al insertar partidos")
             raise
 
     async def delete_all(self):
@@ -102,9 +102,9 @@ class MatchesRepository:
             await self.db.execute(delete(MatchDB))
             await self.db.commit()
             logger.info("Todos los partidos eliminados de PostgreSQL")
-        except SQLAlchemyError as e:
+        except SQLAlchemyError:
             await self.db.rollback()
-            logger.error("Error al eliminar partidos: %s", e)
+            logger.exception("Error al eliminar partidos")
             raise
 
     def _to_pydantic(self, row: MatchDB) -> Match:

--- a/backend/app/routes/history.py
+++ b/backend/app/routes/history.py
@@ -38,7 +38,7 @@ async def complete_combination(combination_id: str):
     comb_service = get_combination_service()
     prob_service = get_probability_service()
 
-    combination = await comb_service.get_combination(combination_id)
+    await comb_service.get_combination(combination_id)
 
     # Calcular resultado final
     result = await prob_service.calculate_combination(combination_id)


### PR DESCRIPTION
## Resumen

Este PR aplica mejoras de Maintainability reportadas por SonarCloud en el backend.

## Cambios realizados

- Se migraron parámetros y dependencias de FastAPI a `Annotated`.
- Se eliminó un import no usado.
- Se reemplazaron logs con `f-string` por lazy logging.
- Se dejaron logs estáticos cuando podían incluir datos controlados por el usuario.
- Se eliminaron variables locales no usadas.
- Se reemplazó `logger.error` dentro de bloques `except` por `logger.exception`.

## Validaciones realizadas

Se ejecutaron los tests del backend correctamente:

```bash
./venv/Scripts/python.exe -m pytest tests/ -v --tb=short
