### PR TITLE
refactor(config): eliminar campos duplicados de settings

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -16,8 +16,6 @@ class Settings(BaseSettings):
     # PostgreSQL
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/oddsengine"
     database_sync_url: str = "postgresql://postgres:postgres@localhost:5432/oddsengine"
-    DATABASE_URL: str = "sqlite+aiosqlite:///./test.db"
-    DEBUG: bool = False
 
     # Modo de datos: "mock" usa datos en memoria, "database" usa PostgreSQL
     data_mode: str = "mock"


### PR DESCRIPTION
## Resumen

Este PR aplica mejoras de Maintainability reportadas por SonarCloud en el backend, sin cambiar la funcionalidad de la aplicación.

El objetivo es reducir deuda técnica manteniendo el Quality Gate en verde y sin modificar endpoints, respuestas, frontend, Docker, workflows ni archivos `.env`.

## Cambios realizados

### Bloque 1A — Annotated e import no usado

- Se eliminó un import no usado en `mock_stats_provider.py`.
- Se migraron parámetros y dependencias de FastAPI a `Annotated`.

### Bloque 2 — Logging

- Se reemplazaron logs con `f-string` por lazy logging.
- Se dejaron logs estáticos cuando podían incluir datos controlados por el usuario.
- Se mantuvo el comportamiento funcional de logging.

### Bloque 3A — Issues simples de Maintainability

- Se eliminó una variable local no usada.
- Se eliminó una asignación local innecesaria.
- Se reemplazó `logger.error` dentro de bloques `except` por `logger.exception`.

### Bloque 3B — Excepciones específicas de bajo riesgo

- Se reemplazó `except Exception` por `except SQLAlchemyError` en el health check de base de datos.
- Se reemplazó `except Exception` por `except NotFoundException` en el cálculo de combinadas.
- Se dejaron sin modificar los `except Exception` justificados en startup/shutdown y manejo transaccional.

### Bloque 4A — Constantes en providers mock

- Se extrajeron constantes para literales duplicados en providers mock.
- Se reemplazaron nombres de jugadores repetidos por constantes.
- Se reemplazó el literal repetido `"Grand Slam"` por una constante.

### Bloque 5 — Configuración

- Se eliminaron campos duplicados en `Settings`:
  - `DATABASE_URL`
  - `DEBUG`
- Se mantuvieron los campos correctos en lowercase:
  - `database_url`
  - `debug`
- No se cambiaron variables de entorno ni comportamiento de configuración.

## Validaciones realizadas

Se ejecutaron todos los tests del backend correctamente:

```bash
./venv/Scripts/python.exe -m pytest tests/ -v --tb=short
