### PR TITLE
refactor(metrics): extraer logica del dashboard

### DIFF
--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -72,55 +72,46 @@ def _parse_metric_line(linea: str):
     return metric_name, labels, valor
 
 
-def setup_metrics(app: FastAPI):
+def _collect_latency_metrics(metrics_text: str) -> tuple[dict, dict]:
+    sumas_latencia: dict = {}
+    conteos_peticiones: dict = {}
+    for linea in metrics_text.splitlines():
+        parsed = _parse_metric_line(linea)
+        if parsed is None:
+            continue
+        metrica, labels, valor = parsed
+        handler = labels.get("handler", "unknown")
+        method = labels.get("method", "unknown")
+        status = labels.get("status", "unknown")
+        key = (method, handler, status)
+        if metrica == "http_request_duration_seconds_sum":
+            sumas_latencia[key] = valor
+        elif metrica == "http_request_duration_seconds_count":
+            conteos_peticiones[key] = int(valor)
+    return sumas_latencia, conteos_peticiones
 
-    # 1. Monitoreo y exposición de métricas nativas
-    Instrumentator().instrument(app).expose(app)
 
-    # 2. Dashboard interactivo
-    @app.get("/dashboard", response_class=HTMLResponse, include_in_schema=False)
-    async def latencies_dashboard():
-        data_cruda = generate_latest(REGISTRY).decode("utf-8")
-        lineas = data_cruda.splitlines()
+def _consolidate_latency_data(sumas_latencia: dict, conteos_peticiones: dict) -> list[tuple]:
+    datos = []
+    for key in conteos_peticiones:
+        method, handler, status = key
+        total = conteos_peticiones[key]
+        suma = sumas_latencia.get(key, 0.0)
+        promedio = round((suma / total) * 1000, 1) if total > 0 else 0
+        datos.append((method, handler, status, total, promedio))
+    datos.sort(key=lambda x: x[4], reverse=True)
+    return datos
 
-        sumas_latencia = {}
-        conteos_peticiones = {}
 
-        for linea in lineas:
-            parsed = _parse_metric_line(linea)
-            if parsed is None:
-                continue
-
-            metrica, labels, valor = parsed
-            handler = labels.get("handler", "unknown")
-            method = labels.get("method", "unknown")
-            status = labels.get("status", "unknown")
-
-            key = (method, handler, status)
-
-            if metrica == "http_request_duration_seconds_sum":
-                sumas_latencia[key] = valor
-            elif metrica == "http_request_duration_seconds_count":
-                conteos_peticiones[key] = int(valor)
-
-        datos_consolidados = []
-        for key in conteos_peticiones:
-            method, handler, status = key
-            total = conteos_peticiones[key]
-            suma = sumas_latencia.get(key, 0.0)
-            promedio = round((suma / total) * 1000, 1) if total > 0 else 0
-            datos_consolidados.append((method, handler, status, total, promedio))
-            
-        datos_consolidados.sort(key=lambda x: x[4], reverse=True)
-
-        filas_tabla = ""
-        for method, handler, status, total, promedio in datos_consolidados:
-            badge_status = _status_badge_class(status)
-            evaluacion = _latency_evaluation(promedio)
-
-            alerta = "table-danger fw-bold" if promedio > 500 else ""
-
-            filas_tabla += f"""
+def _build_latency_table_rows(datos_consolidados: list[tuple]) -> str:
+    if not datos_consolidados:
+        return '<tr><td colspan="6" class="text-center text-muted py-4">No hay peticiones registradas aún. Presiona el botón de arriba para generar tráfico de prueba.</td></tr>'
+    filas = ""
+    for method, handler, status, total, promedio in datos_consolidados:
+        badge_status = _status_badge_class(status)
+        evaluacion = _latency_evaluation(promedio)
+        alerta = "table-danger fw-bold" if promedio > 500 else ""
+        filas += f"""
             <tr class="{alerta}">
                 <td><span class="badge bg-dark">{method}</span></td>
                 <td><code>{handler}</code></td>
@@ -130,6 +121,21 @@ def setup_metrics(app: FastAPI):
                 <td>{evaluacion}</td>
             </tr>
             """
+    return filas
+
+
+def setup_metrics(app: FastAPI):
+
+    # 1. Monitoreo y exposición de métricas nativas
+    Instrumentator().instrument(app).expose(app)
+
+    # 2. Dashboard interactivo
+    @app.get("/dashboard", response_class=HTMLResponse, include_in_schema=False)
+    async def latencies_dashboard():
+        data_cruda = generate_latest(REGISTRY).decode("utf-8")
+        sumas, conteos = _collect_latency_metrics(data_cruda)
+        datos = _consolidate_latency_data(sumas, conteos)
+        filas_tabla = _build_latency_table_rows(datos)
 
         html_template = """
         <!DOCTYPE html>
@@ -345,7 +351,4 @@ def setup_metrics(app: FastAPI):
         </html>
         """
         
-        if not filas_tabla:
-            filas_tabla = '<tr><td colspan="6" class="text-center text-muted py-4">No hay peticiones registradas aún. Presiona el botón de arriba para generar tráfico de prueba.</td></tr>'
-            
         return html_template.replace("{{FILAS_TABLA}}", filas_tabla)

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -10,6 +10,8 @@ import pytest
 from app.core.metrics import (
     _parse_labels, _parse_metric_line,
     _status_badge_class, _latency_evaluation,
+    _collect_latency_metrics, _consolidate_latency_data,
+    _build_latency_table_rows,
 )
 
 
@@ -139,3 +141,90 @@ class TestLatencyEvaluation:
 
     def test_lento(self):
         assert "Lento" in _latency_evaluation(600)
+
+
+SAMPLE_METRICS_TEXT = "\n".join([
+    "# HELP http_request_duration_seconds_sum Total duration",
+    "# TYPE http_request_duration_seconds_sum summary",
+    'http_request_duration_seconds_sum{method="GET",handler="/health",status="200"} 0.5',
+    'http_request_duration_seconds_count{method="GET",handler="/health",status="200"} 10.0',
+    'http_request_duration_seconds_sum{method="POST",handler="/api/auth/login",status="201"} 1.2',
+    'http_request_duration_seconds_count{method="POST",handler="/api/auth/login",status="201"} 4.0',
+    'python_gc_objects_collected_total{generation="0"} 1234.0',
+])
+
+
+class TestCollectLatencyMetrics:
+
+    def test_collects_sum_and_count(self):
+        sumas, conteos = _collect_latency_metrics(SAMPLE_METRICS_TEXT)
+        key = ("GET", "/health", "200")
+        assert key in sumas
+        assert sumas[key] == pytest.approx(0.5)
+        assert conteos[key] == 10
+
+    def test_ignores_unrelated_metrics(self):
+        sumas, conteos = _collect_latency_metrics(SAMPLE_METRICS_TEXT)
+        assert len(sumas) == 2
+        assert len(conteos) == 2
+
+    def test_empty_input(self):
+        sumas, conteos = _collect_latency_metrics("")
+        assert sumas == {}
+        assert conteos == {}
+
+
+class TestConsolidateLatencyData:
+
+    def test_calculates_average_ms(self):
+        sumas = {("GET", "/health", "200"): 0.5}
+        conteos = {("GET", "/health", "200"): 10}
+        datos = _consolidate_latency_data(sumas, conteos)
+        assert len(datos) == 1
+        method, handler, status, total, promedio = datos[0]
+        assert total == 10
+        assert promedio == pytest.approx(50.0)
+
+    def test_sorts_by_latency_descending(self):
+        sumas = {
+            ("GET", "/fast", "200"): 0.1,
+            ("GET", "/slow", "200"): 5.0,
+        }
+        conteos = {
+            ("GET", "/fast", "200"): 10,
+            ("GET", "/slow", "200"): 10,
+        }
+        datos = _consolidate_latency_data(sumas, conteos)
+        assert datos[0][1] == "/slow"
+        assert datos[1][1] == "/fast"
+
+    def test_zero_count_returns_zero_average(self):
+        sumas = {("GET", "/x", "200"): 1.0}
+        conteos = {("GET", "/x", "200"): 0}
+        datos = _consolidate_latency_data(sumas, conteos)
+        assert datos[0][4] == 0
+
+    def test_empty_input(self):
+        assert _consolidate_latency_data({}, {}) == []
+
+
+class TestBuildLatencyTableRows:
+
+    def test_empty_returns_placeholder(self):
+        result = _build_latency_table_rows([])
+        assert "No hay peticiones registradas" in result
+
+    def test_generates_html_rows(self):
+        datos = [("GET", "/health", "200", 10, 50.0)]
+        result = _build_latency_table_rows(datos)
+        assert "GET" in result
+        assert "/health" in result
+        assert "200" in result
+        assert "50.0 ms" in result
+        assert "bg-success" in result
+
+    def test_slow_endpoint_has_alert(self):
+        datos = [("POST", "/slow", "500", 5, 600.0)]
+        result = _build_latency_table_rows(datos)
+        assert "table-danger" in result
+        assert "bg-danger" in result


### PR DESCRIPTION
## Resumen

Este PR aplica mejoras de Maintainability reportadas por SonarCloud en el backend, sin cambiar la funcionalidad de la aplicación.

El objetivo es reducir deuda técnica manteniendo el Quality Gate en verde y sin modificar endpoints, respuestas, frontend, Docker, workflows ni archivos `.env`.

## Cambios realizados

### Bloque 1A — Annotated e import no usado

- Se eliminó un import no usado en `mock_stats_provider.py`.
- Se migraron parámetros y dependencias de FastAPI a `Annotated`.

### Bloque 2 — Logging

- Se reemplazaron logs con `f-string` por lazy logging.
- Se dejaron logs estáticos cuando podían incluir datos controlados por el usuario.
- Se mantuvo el comportamiento funcional de logging.

### Bloque 3A — Issues simples de Maintainability

- Se eliminó una variable local no usada.
- Se eliminó una asignación local innecesaria.
- Se reemplazó `logger.error` dentro de bloques `except` por `logger.exception`.

### Bloque 3B — Excepciones específicas de bajo riesgo

- Se reemplazó `except Exception` por `except SQLAlchemyError` en el health check de base de datos.
- Se reemplazó `except Exception` por `except NotFoundException` en el cálculo de combinadas.
- Se dejaron sin modificar los `except Exception` justificados en startup/shutdown y manejo transaccional.

### Bloque 4A — Constantes en providers mock

- Se extrajeron constantes para literales duplicados en providers mock.
- Se reemplazaron nombres de jugadores repetidos por constantes.
- Se reemplazó el literal repetido `"Grand Slam"` por una constante.

### Bloque 5 — Configuración

- Se eliminaron campos duplicados en `Settings`:
  - `DATABASE_URL`
  - `DEBUG`
- Se mantuvieron los campos correctos en lowercase:
  - `database_url`
  - `debug`
- No se cambiaron variables de entorno ni comportamiento de configuración.

### Bloque 6 — Métricas

- Se redujo la complejidad cognitiva del dashboard de métricas.
- Se extrajo el parseo de métricas Prometheus a `_collect_latency_metrics`.
- Se extrajo la consolidación de datos a `_consolidate_latency_data`.
- Se extrajo la generación de filas HTML a `_build_latency_table_rows`.
- Se mantuvo el mismo HTML visible y el mismo comportamiento del dashboard.
- Se agregaron tests unitarios para las nuevas funciones auxiliares.

## Validaciones realizadas

Se ejecutaron todos los tests del backend correctamente:

```bash
./venv/Scripts/python.exe -m pytest tests/ -v --tb=short

