### PR TITLE
refactor(backend): completar limpieza de async en combinadas

### DIFF
--- a/backend/app/routes/combinations.py
+++ b/backend/app/routes/combinations.py
@@ -90,7 +90,7 @@ async def get_combination(combination_id: str):
 async def delete_combination(combination_id: str):
     """Elimina una combinada completa."""
     service = get_combination_service()
-    await service.delete_combination(combination_id)
+    service.delete_combination(combination_id)
     logger.info("DELETE /combinations — combinada eliminada")
 
     return {"message": f"Combinada '{combination_id}' eliminada correctamente"}
@@ -131,7 +131,7 @@ async def remove_match_from_combination(combination_id: str, match_id: str):
     - El partido debe estar en la combinada
     """
     service = get_combination_service()
-    result = await service.remove_match_from_combination(
+    result = service.remove_match_from_combination(
         combination_id=combination_id,
         match_id=match_id,
     )

--- a/backend/app/services/combination_service.py
+++ b/backend/app/services/combination_service.py
@@ -102,7 +102,7 @@ class CombinationService:
             message=f"Partido agregado correctamente. Total: {combination.total_selections} selecciones.",
         )
 
-    async def remove_match_from_combination(
+    def remove_match_from_combination(
         self, combination_id: str, match_id: str
     ) -> CombinationResponse:
         """
@@ -140,7 +140,7 @@ class CombinationService:
             message=f"Partido eliminado correctamente. Total: {combination.total_selections} selecciones.",
         )
 
-    async def delete_combination(self, combination_id: str) -> bool:
+    def delete_combination(self, combination_id: str) -> bool:
         """Elimina una combinada completa."""
         # Verificar que existe
         self.get_combination(combination_id)


### PR DESCRIPTION
## Resumen

Este PR aplica mejoras de Maintainability y Reliability reportadas por SonarCloud en el backend, sin cambiar la funcionalidad de la aplicación.

El objetivo es reducir deuda técnica manteniendo el Quality Gate en verde y sin modificar endpoints, respuestas, frontend, Docker, workflows ni archivos `.env`.

## Cambios realizados

### Bloque 1A — Annotated e import no usado

- Se eliminó un import no usado en `mock_stats_provider.py`.
- Se migraron parámetros y dependencias de FastAPI a `Annotated`.

### Bloque 2 — Logging

- Se reemplazaron logs con `f-string` por lazy logging.
- Se dejaron logs estáticos cuando podían incluir datos controlados por el usuario.
- Se mantuvo el comportamiento funcional de logging.

### Bloque 3A — Issues simples de Maintainability

- Se eliminaron variables locales no usadas.
- Se eliminó una asignación local innecesaria.
- Se reemplazó `logger.error` dentro de bloques `except` por `logger.exception`.

### Bloque 3B — Excepciones específicas de bajo riesgo

- Se reemplazó `except Exception` por `except SQLAlchemyError` en el health check de base de datos.
- Se reemplazó `except Exception` por `except NotFoundException` en el cálculo de combinadas.
- Se dejaron sin modificar los `except Exception` justificados en startup/shutdown y manejo transaccional.

### Bloque 4A — Constantes en providers mock

- Se extrajeron constantes para literales duplicados en providers mock.
- Se reemplazaron nombres de jugadores repetidos por constantes.
- Se reemplazó el literal repetido `"Grand Slam"` por una constante.

### Bloque 5 — Configuración

- Se eliminaron campos duplicados en `Settings`:
  - `DATABASE_URL`
  - `DEBUG`
- Se mantuvieron los campos correctos en lowercase:
  - `database_url`
  - `debug`
- No se cambiaron variables de entorno ni comportamiento de configuración.

### Bloque 6 — Métricas

- Se redujo la complejidad cognitiva del dashboard de métricas.
- Se extrajo el parseo de métricas Prometheus a `_collect_latency_metrics`.
- Se extrajo la consolidación de datos a `_consolidate_latency_data`.
- Se extrajo la generación de filas HTML a `_build_latency_table_rows`.
- Se mantuvo el mismo HTML visible y el mismo comportamiento del dashboard.
- Se agregaron tests unitarios para las nuevas funciones auxiliares.

### Bloque 7 — Reliability: async sin await

- Se convirtió `get_current_user()` de `async def` a `def`.
- Se actualizaron los tests de seguridad relacionados.
- Se convirtieron a síncronas funciones de `CombinationService` que no usaban `await`.
- Se actualizaron los callers para remover `await` donde ya no correspondía.
- Se mantuvo `mock_provider.get_match_by_id()` como async por contrato con el provider y se agregó `await asyncio.sleep(0)`.

### Bloque 8 — Corrección de CI

- Se corrigió el caller restante en `routes/combinations.py` para evitar usar `await` sobre una función síncrona.
- Se validó que los tests pasen localmente.

## Validaciones realizadas

Se ejecutaron todos los tests del backend correctamente:

```bash
./venv/Scripts/python.exe -m pytest tests/ -v --tb=short