### PR TITLE
feat(backend): add Telegram notifications for saved combinations

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -27,3 +27,8 @@ JWT_EXPIRE_MINUTES=60
 
 # Telegram Bot (opcional — si vacío, el bot no inicia)
 TELEGRAM_BOT_TOKEN=
+
+# Telegram Notificaciones (opcional — si ENABLED=false, no envía mensajes)
+TELEGRAM_ENABLED=false
+TELEGRAM_CHAT_ID=
+TELEGRAM_LOW_PROBABILITY_THRESHOLD=30.0

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -27,6 +27,9 @@ class Settings(BaseSettings):
 
     # Telegram Bot (opcional — si vacío, el bot no inicia)
     telegram_bot_token: str = ""
+    telegram_enabled: bool = False
+    telegram_chat_id: str = ""
+    telegram_low_probability_threshold: float = 30.0
 
     class Config:
         env_file = ".env"

--- a/backend/app/routes/combinations.py
+++ b/backend/app/routes/combinations.py
@@ -21,6 +21,8 @@ from app.models.combination import (
     CombinationSummary,
 )
 from app.services.combination_service import get_combination_service
+from app.services.probability_service import get_probability_service
+from app.services.telegram_notification_service import get_telegram_notification_service
 
 logger = logging.getLogger("oddsengine")
 
@@ -146,8 +148,25 @@ async def save_combination(combination_id: str):
 
     Guarda tanto la combinada como todas sus selecciones actuales.
     Si la combinada ya existía en BD, actualiza sus selecciones.
+    Envía notificación por Telegram si está configurado.
     """
     service = get_combination_service()
     result = await service.save_combination_to_db(combination_id)
     logger.info("POST /combinations/save — combinada guardada en BD")
+
+    try:
+        combination = service.get_combination(combination_id)
+        prob_service = get_probability_service()
+        prob_result = await prob_service.calculate_combination(combination_id)
+
+        notifier = get_telegram_notification_service()
+        await notifier.send_combination_saved(
+            combination_id=combination_id,
+            total_selections=combination.total_selections,
+            total_probability=prob_result.total_probability,
+            risk_level=prob_result.risk_level.value,
+        )
+    except Exception:
+        logger.warning("No se pudo enviar notificación Telegram")
+
     return result

--- a/backend/app/services/telegram_notification_service.py
+++ b/backend/app/services/telegram_notification_service.py
@@ -1,0 +1,132 @@
+"""Servicio de notificaciones por Telegram para combinadas guardadas."""
+
+import logging
+from typing import Optional
+
+import httpx
+
+from app.core.config import get_settings
+
+logger = logging.getLogger("oddsengine")
+
+TELEGRAM_API_URL = "https://api.telegram.org/bot{token}/sendMessage"
+
+
+class TelegramNotificationService:
+
+    def __init__(
+        self,
+        enabled: Optional[bool] = None,
+        token: Optional[str] = None,
+        chat_id: Optional[str] = None,
+        threshold: Optional[float] = None,
+        http_client: Optional[httpx.AsyncClient] = None,
+    ):
+        settings = get_settings()
+        self._enabled = enabled if enabled is not None else settings.telegram_enabled
+        self._token = token if token is not None else settings.telegram_bot_token
+        self._chat_id = chat_id if chat_id is not None else settings.telegram_chat_id
+        self._threshold = (
+            threshold if threshold is not None
+            else settings.telegram_low_probability_threshold
+        )
+        self._http_client = http_client
+
+    def _is_configured(self) -> bool:
+        if not self._enabled:
+            return False
+        if not self._token:
+            logger.warning("Telegram habilitado pero falta TELEGRAM_BOT_TOKEN")
+            return False
+        if not self._chat_id:
+            logger.warning("Telegram habilitado pero falta TELEGRAM_CHAT_ID")
+            return False
+        return True
+
+    def _format_message(
+        self,
+        combination_id: str,
+        total_selections: int,
+        total_probability: float,
+        risk_level: str,
+    ) -> str:
+        lines = [
+            "✅ OddsEngine — Combinada guardada",
+            f"ID: {combination_id}",
+            f"Selecciones: {total_selections}",
+            f"Probabilidad estimada: {total_probability}%",
+            f"Riesgo: {risk_level.upper()}",
+        ]
+
+        if self._is_high_risk(total_probability, risk_level):
+            lines.append("")
+            lines.append(
+                "⚠️ Alerta: la probabilidad de éxito es baja. "
+                "Revisa tu selección antes de apostar."
+            )
+
+        return "\n".join(lines)
+
+    def _is_high_risk(self, total_probability: float, risk_level: str) -> bool:
+        return (
+            risk_level.upper() == "HIGH"
+            or total_probability < self._threshold
+        )
+
+    async def send_combination_saved(
+        self,
+        combination_id: str,
+        total_selections: int,
+        total_probability: float,
+        risk_level: str,
+    ) -> bool:
+        if not self._is_configured():
+            return False
+
+        text = self._format_message(
+            combination_id, total_selections, total_probability, risk_level
+        )
+        return await self._send_message(text)
+
+    async def _send_message(self, text: str) -> bool:
+        url = TELEGRAM_API_URL.format(token=self._token)
+        payload = {"chat_id": self._chat_id, "text": text, "parse_mode": "HTML"}
+
+        try:
+            if self._http_client:
+                response = self._http_client
+                resp = await response.post(url, json=payload, timeout=10)
+            else:
+                async with httpx.AsyncClient() as client:
+                    resp = await client.post(url, json=payload, timeout=10)
+
+            if resp.status_code == 200:
+                logger.info("Notificación Telegram enviada correctamente")
+                return True
+
+            logger.warning(
+                "Telegram respondió con status %s", resp.status_code
+            )
+            return False
+
+        except httpx.TimeoutException:
+            logger.warning("Timeout enviando notificación Telegram")
+            return False
+        except Exception:
+            logger.warning("Error enviando notificación Telegram")
+            return False
+
+
+_notification_service: Optional[TelegramNotificationService] = None
+
+
+def get_telegram_notification_service() -> TelegramNotificationService:
+    global _notification_service
+    if _notification_service is None:
+        _notification_service = TelegramNotificationService()
+    return _notification_service
+
+
+def reset_telegram_notification_service() -> None:
+    global _notification_service
+    _notification_service = None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -25,13 +25,16 @@ def reset_in_memory_state():
     import app.services.combination_service as _cs
     from app.core.storage import reset_storage
     from app.services.auth_service import reset_auth_service
+    from app.services.telegram_notification_service import reset_telegram_notification_service
 
     reset_storage()
     reset_auth_service()
+    reset_telegram_notification_service()
     _cs._combination_service = None
     yield
     reset_storage()
     reset_auth_service()
+    reset_telegram_notification_service()
     _cs._combination_service = None
 
 

--- a/backend/tests/test_telegram_notification_service.py
+++ b/backend/tests/test_telegram_notification_service.py
@@ -1,0 +1,386 @@
+"""Tests para el servicio de notificaciones Telegram."""
+
+import logging
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import httpx
+
+from app.services.telegram_notification_service import TelegramNotificationService
+
+
+def _make_service(enabled=True, token="fake-token", chat_id="12345", threshold=30.0, http_client=None):
+    return TelegramNotificationService(
+        enabled=enabled,
+        token=token,
+        chat_id=chat_id,
+        threshold=threshold,
+        http_client=http_client,
+    )
+
+
+class TestTelegramDisabled:
+
+    @pytest.mark.anyio
+    async def test_send_disabled_returns_false(self):
+        service = _make_service(enabled=False)
+        result = await service.send_combination_saved(
+            combination_id="comb_001",
+            total_selections=3,
+            total_probability=45.0,
+            risk_level="medium",
+        )
+        assert result is False
+
+    @pytest.mark.anyio
+    async def test_send_disabled_does_not_call_http(self):
+        mock_client = AsyncMock()
+        service = _make_service(enabled=False, http_client=mock_client)
+        await service.send_combination_saved(
+            combination_id="comb_001",
+            total_selections=2,
+            total_probability=60.0,
+            risk_level="low",
+        )
+        mock_client.post.assert_not_called()
+
+
+class TestMissingConfig:
+
+    @pytest.mark.anyio
+    async def test_missing_token_returns_false(self):
+        service = _make_service(token="")
+        result = await service.send_combination_saved(
+            combination_id="comb_001",
+            total_selections=2,
+            total_probability=50.0,
+            risk_level="medium",
+        )
+        assert result is False
+
+    @pytest.mark.anyio
+    async def test_missing_token_logs_warning(self, caplog):
+        service = _make_service(token="")
+        with caplog.at_level(logging.WARNING, logger="oddsengine"):
+            await service.send_combination_saved(
+                combination_id="comb_001",
+                total_selections=2,
+                total_probability=50.0,
+                risk_level="medium",
+            )
+        assert "falta TELEGRAM_BOT_TOKEN" in caplog.text
+
+    @pytest.mark.anyio
+    async def test_missing_chat_id_returns_false(self):
+        service = _make_service(chat_id="")
+        result = await service.send_combination_saved(
+            combination_id="comb_001",
+            total_selections=2,
+            total_probability=50.0,
+            risk_level="medium",
+        )
+        assert result is False
+
+    @pytest.mark.anyio
+    async def test_missing_chat_id_logs_warning(self, caplog):
+        service = _make_service(chat_id="")
+        with caplog.at_level(logging.WARNING, logger="oddsengine"):
+            await service.send_combination_saved(
+                combination_id="comb_001",
+                total_selections=2,
+                total_probability=50.0,
+                risk_level="medium",
+            )
+        assert "falta TELEGRAM_CHAT_ID" in caplog.text
+
+
+class TestSendSuccess:
+
+    @pytest.mark.anyio
+    async def test_send_success_returns_true(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        service = _make_service(http_client=mock_client)
+        result = await service.send_combination_saved(
+            combination_id="comb_abc",
+            total_selections=3,
+            total_probability=55.0,
+            risk_level="low",
+        )
+        assert result is True
+
+    @pytest.mark.anyio
+    async def test_send_calls_telegram_api(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        service = _make_service(http_client=mock_client)
+        await service.send_combination_saved(
+            combination_id="comb_abc",
+            total_selections=2,
+            total_probability=40.0,
+            risk_level="medium",
+        )
+
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        url = call_args[0][0]
+        assert "api.telegram.org" in url
+        assert "sendMessage" in url
+
+    @pytest.mark.anyio
+    async def test_send_includes_chat_id_in_payload(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        service = _make_service(chat_id="99999", http_client=mock_client)
+        await service.send_combination_saved(
+            combination_id="comb_abc",
+            total_selections=2,
+            total_probability=40.0,
+            risk_level="medium",
+        )
+
+        payload = mock_client.post.call_args[1]["json"]
+        assert payload["chat_id"] == "99999"
+
+
+class TestSendErrors:
+
+    @pytest.mark.anyio
+    async def test_http_error_returns_false(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        service = _make_service(http_client=mock_client)
+        result = await service.send_combination_saved(
+            combination_id="comb_001",
+            total_selections=2,
+            total_probability=50.0,
+            risk_level="medium",
+        )
+        assert result is False
+
+    @pytest.mark.anyio
+    async def test_timeout_returns_false(self):
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = httpx.TimeoutException("timeout")
+
+        service = _make_service(http_client=mock_client)
+        result = await service.send_combination_saved(
+            combination_id="comb_001",
+            total_selections=2,
+            total_probability=50.0,
+            risk_level="medium",
+        )
+        assert result is False
+
+    @pytest.mark.anyio
+    async def test_generic_exception_returns_false(self):
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = RuntimeError("network down")
+
+        service = _make_service(http_client=mock_client)
+        result = await service.send_combination_saved(
+            combination_id="comb_001",
+            total_selections=2,
+            total_probability=50.0,
+            risk_level="medium",
+        )
+        assert result is False
+
+
+class TestMessageFormatting:
+
+    @pytest.mark.anyio
+    async def test_low_risk_no_alert(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        service = _make_service(http_client=mock_client, threshold=30.0)
+        await service.send_combination_saved(
+            combination_id="comb_low",
+            total_selections=2,
+            total_probability=55.0,
+            risk_level="low",
+        )
+
+        payload = mock_client.post.call_args[1]["json"]
+        text = payload["text"]
+        assert "comb_low" in text
+        assert "55.0%" in text
+        assert "⚠️ Alerta" not in text
+
+    @pytest.mark.anyio
+    async def test_high_risk_includes_alert(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        service = _make_service(http_client=mock_client, threshold=30.0)
+        await service.send_combination_saved(
+            combination_id="comb_high",
+            total_selections=4,
+            total_probability=8.5,
+            risk_level="high",
+        )
+
+        payload = mock_client.post.call_args[1]["json"]
+        text = payload["text"]
+        assert "⚠️ Alerta" in text
+        assert "8.5%" in text
+
+    @pytest.mark.anyio
+    async def test_medium_risk_below_threshold_includes_alert(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        service = _make_service(http_client=mock_client, threshold=30.0)
+        await service.send_combination_saved(
+            combination_id="comb_med",
+            total_selections=3,
+            total_probability=25.0,
+            risk_level="medium",
+        )
+
+        payload = mock_client.post.call_args[1]["json"]
+        text = payload["text"]
+        assert "⚠️ Alerta" in text
+
+    @pytest.mark.anyio
+    async def test_medium_risk_above_threshold_no_alert(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        service = _make_service(http_client=mock_client, threshold=30.0)
+        await service.send_combination_saved(
+            combination_id="comb_ok",
+            total_selections=2,
+            total_probability=45.0,
+            risk_level="medium",
+        )
+
+        payload = mock_client.post.call_args[1]["json"]
+        text = payload["text"]
+        assert "⚠️ Alerta" not in text
+
+
+class TestTokenNotInLogs:
+
+    @pytest.mark.anyio
+    async def test_token_not_logged_on_success(self, caplog):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        service = _make_service(token="super-secret-token-xyz", http_client=mock_client)
+        with caplog.at_level(logging.DEBUG, logger="oddsengine"):
+            await service.send_combination_saved(
+                combination_id="comb_001",
+                total_selections=2,
+                total_probability=50.0,
+                risk_level="medium",
+            )
+        assert "super-secret-token-xyz" not in caplog.text
+
+    @pytest.mark.anyio
+    async def test_token_not_logged_on_error(self, caplog):
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = RuntimeError("fail")
+
+        service = _make_service(token="secret-tok-999", http_client=mock_client)
+        with caplog.at_level(logging.DEBUG, logger="oddsengine"):
+            await service.send_combination_saved(
+                combination_id="comb_001",
+                total_selections=2,
+                total_probability=50.0,
+                risk_level="medium",
+            )
+        assert "secret-tok-999" not in caplog.text
+
+
+class TestIntegrationWithSave:
+
+    @pytest.mark.anyio
+    async def test_notification_failure_does_not_break_save(self, client):
+        """El guardado de combinada funciona aunque Telegram falle."""
+        resp = await client.post("/api/combinations")
+        comb_id = resp.json()["id"]
+        await client.post(
+            f"/api/combinations/{comb_id}/matches",
+            json={"match_id": "match_001"},
+        )
+        await client.post(
+            f"/api/combinations/{comb_id}/matches",
+            json={"match_id": "match_002"},
+        )
+
+        with patch(
+            "app.routes.combinations.get_telegram_notification_service"
+        ) as mock_get, patch(
+            "app.core.config.get_settings"
+        ) as mock_settings:
+            mock_s = MagicMock()
+            mock_s.data_mode = "mock"
+            mock_settings.return_value = mock_s
+
+            mock_notifier = AsyncMock()
+            mock_notifier.send_combination_saved.side_effect = RuntimeError("Telegram down")
+            mock_get.return_value = mock_notifier
+
+            resp = await client.post(f"/api/combinations/{comb_id}/save")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["combination_id"] == comb_id
+
+    @pytest.mark.anyio
+    async def test_save_calls_notification_service(self, client):
+        """Verificar que el endpoint de guardar intenta notificar."""
+        resp = await client.post("/api/combinations")
+        comb_id = resp.json()["id"]
+        await client.post(
+            f"/api/combinations/{comb_id}/matches",
+            json={"match_id": "match_001"},
+        )
+        await client.post(
+            f"/api/combinations/{comb_id}/matches",
+            json={"match_id": "match_002"},
+        )
+
+        with patch(
+            "app.routes.combinations.get_telegram_notification_service"
+        ) as mock_get, patch(
+            "app.core.config.get_settings"
+        ) as mock_settings:
+            mock_s = MagicMock()
+            mock_s.data_mode = "mock"
+            mock_settings.return_value = mock_s
+
+            mock_notifier = AsyncMock()
+            mock_notifier.send_combination_saved.return_value = True
+            mock_get.return_value = mock_notifier
+
+            await client.post(f"/api/combinations/{comb_id}/save")
+
+        mock_notifier.send_combination_saved.assert_called_once()
+        call_kwargs = mock_notifier.send_combination_saved.call_args[1]
+        assert call_kwargs["combination_id"] == comb_id
+        assert call_kwargs["total_selections"] == 2


### PR DESCRIPTION
## Resumen

Se implementa la integración funcional de Telegram como proveedor de mensajería para OddsEngine.

Cuando una combinada/apuesta se guarda correctamente desde el endpoint `POST /api/combinations/{id}/save`, el backend puede enviar una notificación por Telegram confirmando el guardado. Si la probabilidad es baja o el riesgo es alto, el mensaje incluye una alerta especial.

## Cambios realizados

- Se agregaron variables de configuración para Telegram:
  - `TELEGRAM_ENABLED`
  - `TELEGRAM_BOT_TOKEN`
  - `TELEGRAM_CHAT_ID`
  - `TELEGRAM_LOW_PROBABILITY_THRESHOLD`

- Se creó el servicio `telegram_notification_service.py` para:
  - validar configuración de Telegram,
  - formatear mensajes,
  - enviar mensajes mediante `httpx`,
  - manejar errores sin romper el flujo principal,
  - evitar exponer tokens en logs.

- Se integró el envío de notificaciones al flujo de guardado de combinadas.
- Se documentaron las variables nuevas en `.env.example`.
- Se agregaron tests con mocks para evitar llamadas reales a Telegram en CI.
- Se resetea el singleton del servicio de notificaciones entre tests.

## Validación

Resultado local:

```txt
249 passed, 6 skipped, 0 failed
Coverage total: 93%

