### PR TITLE
fix(backend): support Telegram notifications with PostgreSQL persistence

### DIFF
--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -1,7 +1,5 @@
 [run]
 source = app
-omit =
-    app/models/db_models.py
 
 [report]
 exclude_lines =

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -50,6 +50,7 @@ async def get_db():
 
 async def create_tables():
     """Crear todas las tablas definidas en los modelos."""
+    import app.models.db_models  # noqa: F401 — registra modelos en Base.metadata
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 

--- a/backend/app/models/db_models.py
+++ b/backend/app/models/db_models.py
@@ -4,7 +4,7 @@ Modelos SQLAlchemy para las tablas de PostgreSQL.
 
 from sqlalchemy import Column, String, Integer, Float, DateTime, ForeignKey, Text
 from sqlalchemy.orm import relationship
-from datetime import datetime, timezone
+from datetime import datetime
 
 from app.core.database import Base
 
@@ -35,9 +35,9 @@ class CombinationDB(Base):
     __tablename__ = "combinations"
 
     id = Column(String(50), primary_key=True)
-    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
-    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc),
-                        onupdate=lambda: datetime.now(timezone.utc))
+    created_at = Column(DateTime, default=lambda: datetime.now())
+    updated_at = Column(DateTime, default=lambda: datetime.now(),
+                        onupdate=lambda: datetime.now())
 
     selections = relationship("SelectionDB", back_populates="combination",
                               cascade="all, delete-orphan")
@@ -54,7 +54,7 @@ class SelectionDB(Base):
     player_away_name = Column(String(100), nullable=False)
     tournament_name = Column(String(100), nullable=False)
     match_date = Column(DateTime, nullable=False)
-    added_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    added_at = Column(DateTime, default=lambda: datetime.now())
 
     combination = relationship("CombinationDB", back_populates="selections")
 

--- a/backend/app/routes/combinations.py
+++ b/backend/app/routes/combinations.py
@@ -160,13 +160,15 @@ async def save_combination(combination_id: str):
         prob_result = await prob_service.calculate_combination(combination_id)
 
         notifier = get_telegram_notification_service()
-        await notifier.send_combination_saved(
+        sent = await notifier.send_combination_saved(
             combination_id=combination_id,
             total_selections=combination.total_selections,
             total_probability=prob_result.total_probability,
             risk_level=prob_result.risk_level.value,
         )
-    except Exception:
-        logger.warning("No se pudo enviar notificación Telegram")
+        if not sent:
+            logger.info("Notificación Telegram no enviada (deshabilitado o no configurado)")
+    except Exception as exc:
+        logger.warning("No se pudo enviar notificación Telegram: %s", exc)
 
     return result

--- a/backend/app/services/combination_service.py
+++ b/backend/app/services/combination_service.py
@@ -11,7 +11,7 @@ Responsabilidades:
 """
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Optional
 
 from app.models.combination import (
@@ -88,7 +88,7 @@ class CombinationService:
 
         # Agregar a la combinada
         combination.selections.append(selection)
-        combination.updated_at = datetime.now(timezone.utc)
+        combination.updated_at = datetime.now()
         self._storage.save_combination(combination)
 
         logger.info("Partido agregado a combinada")
@@ -126,7 +126,7 @@ class CombinationService:
         combination.selections = [
             s for s in combination.selections if s.match_id != match_id
         ]
-        combination.updated_at = datetime.now(timezone.utc)
+        combination.updated_at = datetime.now()
         self._storage.save_combination(combination)
 
         logger.info("Partido eliminado de combinada")
@@ -206,7 +206,7 @@ class CombinationService:
                     session.add(db_combination)
                 else:
                     # Actualizar timestamps
-                    db_combination.updated_at = datetime.now(timezone.utc)
+                    db_combination.updated_at = datetime.now()
 
                 # Borrar selecciones anteriores (para hacer upsert limpio)
                 await session.execute(

--- a/backend/app/services/telegram_notification_service.py
+++ b/backend/app/services/telegram_notification_service.py
@@ -34,6 +34,7 @@ class TelegramNotificationService:
 
     def _is_configured(self) -> bool:
         if not self._enabled:
+            logger.debug("Telegram deshabilitado (TELEGRAM_ENABLED=false)")
             return False
         if not self._token:
             logger.warning("Telegram habilitado pero falta TELEGRAM_BOT_TOKEN")

--- a/backend/tests/test_db_models_and_save.py
+++ b/backend/tests/test_db_models_and_save.py
@@ -103,6 +103,34 @@ class TestDbModelsDefaults:
         col = CombinationDB.__table__.c.updated_at
         assert col.onupdate is not None
 
+    def test_combination_created_at_default_callable(self):
+        from app.models.db_models import CombinationDB
+        col = CombinationDB.__table__.c.created_at
+        result = col.default.arg(None)
+        assert isinstance(result, datetime)
+        assert result.tzinfo is None
+
+    def test_combination_updated_at_default_callable(self):
+        from app.models.db_models import CombinationDB
+        col = CombinationDB.__table__.c.updated_at
+        result = col.default.arg(None)
+        assert isinstance(result, datetime)
+        assert result.tzinfo is None
+
+    def test_combination_updated_at_onupdate_callable(self):
+        from app.models.db_models import CombinationDB
+        col = CombinationDB.__table__.c.updated_at
+        result = col.onupdate.arg(None)
+        assert isinstance(result, datetime)
+        assert result.tzinfo is None
+
+    def test_selection_added_at_default_callable(self):
+        from app.models.db_models import SelectionDB
+        col = SelectionDB.__table__.c.added_at
+        result = col.default.arg(None)
+        assert isinstance(result, datetime)
+        assert result.tzinfo is None
+
 
 class TestCreateTables:
 

--- a/backend/tests/test_db_models_and_save.py
+++ b/backend/tests/test_db_models_and_save.py
@@ -1,0 +1,244 @@
+"""
+Tests para modelos SQLAlchemy, create_tables y save_combination_to_db.
+
+Usa SQLite en memoria — no requiere PostgreSQL.
+"""
+
+import pytest
+from datetime import datetime
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from sqlalchemy import select
+
+from app.core.database import Base
+
+TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest.fixture
+async def db_engine():
+    engine = create_async_engine(TEST_DB_URL, echo=False)
+    import app.models.db_models  # noqa: F401
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest.fixture
+async def session_factory(db_engine):
+    return async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+
+
+class TestDbModelsMetadata:
+
+    def test_combinations_table_registered(self):
+        import app.models.db_models  # noqa: F401
+        assert "combinations" in Base.metadata.tables
+
+    def test_selections_table_registered(self):
+        import app.models.db_models  # noqa: F401
+        assert "selections" in Base.metadata.tables
+
+    def test_matches_table_registered(self):
+        import app.models.db_models  # noqa: F401
+        assert "matches" in Base.metadata.tables
+
+    def test_player_stats_table_registered(self):
+        import app.models.db_models  # noqa: F401
+        assert "player_stats" in Base.metadata.tables
+
+    def test_head_to_head_table_registered(self):
+        import app.models.db_models  # noqa: F401
+        assert "head_to_head" in Base.metadata.tables
+
+
+class TestDbModelsDefaults:
+
+    @pytest.mark.anyio
+    async def test_combination_db_defaults_naive_datetime(self, session_factory):
+        from app.models.db_models import CombinationDB
+
+        async with session_factory() as session:
+            async with session.begin():
+                comb = CombinationDB(id="comb_test_001")
+                session.add(comb)
+
+            await session.refresh(comb)
+            assert comb.created_at is not None
+            assert comb.created_at.tzinfo is None
+            assert comb.updated_at is not None
+            assert comb.updated_at.tzinfo is None
+
+    @pytest.mark.anyio
+    async def test_selection_db_defaults_naive_datetime(self, session_factory):
+        from app.models.db_models import CombinationDB, SelectionDB
+
+        async with session_factory() as session:
+            async with session.begin():
+                comb = CombinationDB(id="comb_sel_test")
+                session.add(comb)
+
+            async with session.begin():
+                sel = SelectionDB(
+                    id="sel_test_001",
+                    combination_id="comb_sel_test",
+                    match_id="match_001",
+                    player_home_name="Player A",
+                    player_away_name="Player B",
+                    tournament_name="Test Open",
+                    match_date=datetime(2026, 6, 1, 10, 0),
+                )
+                session.add(sel)
+
+            await session.refresh(sel)
+            assert sel.added_at is not None
+            assert sel.added_at.tzinfo is None
+
+    def test_combination_db_has_onupdate(self):
+        from app.models.db_models import CombinationDB
+        col = CombinationDB.__table__.c.updated_at
+        assert col.onupdate is not None
+
+
+class TestCreateTables:
+
+    @pytest.mark.anyio
+    async def test_create_tables_registers_models(self):
+        from app.core.database import create_tables
+        with patch("app.core.database.engine") as mock_engine:
+            mock_conn = AsyncMock()
+            mock_ctx = AsyncMock()
+            mock_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+            mock_ctx.__aexit__ = AsyncMock(return_value=False)
+            mock_engine.begin.return_value = mock_ctx
+
+            await create_tables()
+
+            mock_conn.run_sync.assert_called_once()
+            assert "combinations" in Base.metadata.tables
+
+
+class TestSaveCombinationToDb:
+
+    @pytest.mark.anyio
+    async def test_save_mock_mode_returns_saved_false(self):
+        from app.services.combination_service import CombinationService
+
+        service = CombinationService()
+        comb = service.create_combination()
+
+        with patch("app.core.config.get_settings") as mock_settings:
+            mock_s = MagicMock()
+            mock_s.data_mode = "mock"
+            mock_settings.return_value = mock_s
+
+            result = await service.save_combination_to_db(comb.id)
+
+        assert result["saved"] is False
+        assert result["combination_id"] == comb.id
+
+    @pytest.mark.anyio
+    async def test_save_database_mode_inserts_combination(self, session_factory):
+        from app.services.combination_service import CombinationService
+        from app.models.db_models import CombinationDB
+
+        service = CombinationService()
+        comb = service.create_combination()
+
+        with patch("app.core.config.get_settings") as mock_settings, \
+             patch("app.core.database.AsyncSessionLocal", session_factory):
+            mock_s = MagicMock()
+            mock_s.data_mode = "database"
+            mock_settings.return_value = mock_s
+
+            result = await service.save_combination_to_db(comb.id)
+
+        assert result["saved"] is True
+        assert result["combination_id"] == comb.id
+
+        async with session_factory() as session:
+            db_comb = await session.get(CombinationDB, comb.id)
+            assert db_comb is not None
+            assert db_comb.created_at.tzinfo is None
+
+    @pytest.mark.anyio
+    async def test_save_database_mode_with_selections(self, session_factory):
+        from app.services.combination_service import CombinationService
+        from app.models.db_models import SelectionDB
+        from app.models.combination import Selection
+
+        service = CombinationService()
+        comb = service.create_combination()
+
+        sel = Selection(
+            match_id="match_001",
+            player_home_name="Carlos Alcaraz",
+            player_away_name="Novak Djokovic",
+            tournament_name="Roland Garros",
+            match_date=datetime(2026, 6, 1, 14, 0),
+        )
+        comb.selections.append(sel)
+
+        with patch("app.core.config.get_settings") as mock_settings, \
+             patch("app.core.database.AsyncSessionLocal", session_factory):
+            mock_s = MagicMock()
+            mock_s.data_mode = "database"
+            mock_settings.return_value = mock_s
+
+            result = await service.save_combination_to_db(comb.id)
+
+        assert result["saved"] is True
+        assert result["total_selections"] == 1
+
+        async with session_factory() as session:
+            rows = (await session.execute(
+                select(SelectionDB).where(SelectionDB.combination_id == comb.id)
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].match_id == "match_001"
+            assert rows[0].added_at.tzinfo is None
+
+    @pytest.mark.anyio
+    async def test_save_database_mode_upsert_updates_existing(self, session_factory):
+        from app.services.combination_service import CombinationService
+        from app.models.db_models import CombinationDB
+        from app.models.combination import Selection
+
+        service = CombinationService()
+        comb = service.create_combination()
+
+        with patch("app.core.config.get_settings") as mock_settings, \
+             patch("app.core.database.AsyncSessionLocal", session_factory):
+            mock_s = MagicMock()
+            mock_s.data_mode = "database"
+            mock_settings.return_value = mock_s
+
+            await service.save_combination_to_db(comb.id)
+
+            sel = Selection(
+                match_id="match_002",
+                player_home_name="Rafa Nadal",
+                player_away_name="Roger Federer",
+                tournament_name="Wimbledon",
+                match_date=datetime(2026, 7, 1, 15, 0),
+            )
+            comb.selections.append(sel)
+
+            result = await service.save_combination_to_db(comb.id)
+
+        assert result["saved"] is True
+        assert result["total_selections"] == 1
+
+    @pytest.mark.anyio
+    async def test_save_nonexistent_combination_raises(self):
+        from app.services.combination_service import CombinationService
+        from app.core.exceptions import NotFoundException
+
+        service = CombinationService()
+
+        with pytest.raises(NotFoundException):
+            await service.save_combination_to_db("comb_nonexistent")

--- a/backend/tests/test_telegram_notification_service.py
+++ b/backend/tests/test_telegram_notification_service.py
@@ -33,6 +33,18 @@ class TestTelegramDisabled:
         assert result is False
 
     @pytest.mark.anyio
+    async def test_send_disabled_logs_debug(self, caplog):
+        service = _make_service(enabled=False)
+        with caplog.at_level(logging.DEBUG, logger="oddsengine"):
+            await service.send_combination_saved(
+                combination_id="comb_001",
+                total_selections=3,
+                total_probability=45.0,
+                risk_level="medium",
+            )
+        assert "deshabilitado" in caplog.text
+
+    @pytest.mark.anyio
     async def test_send_disabled_does_not_call_http(self):
         mock_client = AsyncMock()
         service = _make_service(enabled=False, http_client=mock_client)
@@ -384,3 +396,102 @@ class TestIntegrationWithSave:
         call_kwargs = mock_notifier.send_combination_saved.call_args[1]
         assert call_kwargs["combination_id"] == comb_id
         assert call_kwargs["total_selections"] == 2
+
+    @pytest.mark.anyio
+    async def test_save_mock_mode_still_notifies(self, client):
+        """En DATA_MODE=mock (saved=false), la notificación se dispara igual."""
+        resp = await client.post("/api/combinations")
+        comb_id = resp.json()["id"]
+        await client.post(
+            f"/api/combinations/{comb_id}/matches",
+            json={"match_id": "match_001"},
+        )
+        await client.post(
+            f"/api/combinations/{comb_id}/matches",
+            json={"match_id": "match_002"},
+        )
+
+        with patch(
+            "app.routes.combinations.get_telegram_notification_service"
+        ) as mock_get, patch(
+            "app.core.config.get_settings"
+        ) as mock_settings:
+            mock_s = MagicMock()
+            mock_s.data_mode = "mock"
+            mock_settings.return_value = mock_s
+
+            mock_notifier = AsyncMock()
+            mock_notifier.send_combination_saved.return_value = True
+            mock_get.return_value = mock_notifier
+
+            resp = await client.post(f"/api/combinations/{comb_id}/save")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["saved"] is False
+        mock_notifier.send_combination_saved.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_save_logs_when_notification_not_sent(self, client, caplog):
+        """Si la notificación retorna False, se loggea info descriptivo."""
+        resp = await client.post("/api/combinations")
+        comb_id = resp.json()["id"]
+        await client.post(
+            f"/api/combinations/{comb_id}/matches",
+            json={"match_id": "match_001"},
+        )
+        await client.post(
+            f"/api/combinations/{comb_id}/matches",
+            json={"match_id": "match_002"},
+        )
+
+        with patch(
+            "app.routes.combinations.get_telegram_notification_service"
+        ) as mock_get, patch(
+            "app.core.config.get_settings"
+        ) as mock_settings:
+            mock_s = MagicMock()
+            mock_s.data_mode = "mock"
+            mock_settings.return_value = mock_s
+
+            mock_notifier = AsyncMock()
+            mock_notifier.send_combination_saved.return_value = False
+            mock_get.return_value = mock_notifier
+
+            with caplog.at_level(logging.INFO, logger="oddsengine"):
+                await client.post(f"/api/combinations/{comb_id}/save")
+
+        assert "no enviada" in caplog.text
+
+    @pytest.mark.anyio
+    async def test_save_logs_exception_detail(self, client, caplog):
+        """Si la notificación lanza excepción, el log incluye el motivo."""
+        resp = await client.post("/api/combinations")
+        comb_id = resp.json()["id"]
+        await client.post(
+            f"/api/combinations/{comb_id}/matches",
+            json={"match_id": "match_001"},
+        )
+        await client.post(
+            f"/api/combinations/{comb_id}/matches",
+            json={"match_id": "match_002"},
+        )
+
+        with patch(
+            "app.routes.combinations.get_telegram_notification_service"
+        ) as mock_get, patch(
+            "app.core.config.get_settings"
+        ) as mock_settings:
+            mock_s = MagicMock()
+            mock_s.data_mode = "mock"
+            mock_settings.return_value = mock_s
+
+            mock_notifier = AsyncMock()
+            mock_notifier.send_combination_saved.side_effect = RuntimeError("connection refused")
+            mock_get.return_value = mock_notifier
+
+            with caplog.at_level(logging.WARNING, logger="oddsengine"):
+                resp = await client.post(f"/api/combinations/{comb_id}/save")
+
+        assert resp.status_code == 200
+        assert "connection refused" in caplog.text


### PR DESCRIPTION
## Resumen

Se implementa la integración funcional de Telegram como proveedor de mensajería para OddsEngine.

Ahora, cuando una combinada se guarda correctamente desde el endpoint `POST /api/combinations/{id}/save`, el backend envía una notificación real por Telegram confirmando el guardado de la combinada, incluyendo:

- ID de la combinada.
- Número de selecciones.
- Probabilidad estimada.
- Nivel de riesgo.
- Alerta si la probabilidad es baja.

Además, se corrigieron problemas necesarios para que el flujo funcione tanto en modo `mock` como en modo `database` con PostgreSQL.

---

## Cambios principales

### Telegram

- Se agregó un servicio de notificaciones de Telegram.
- Se integró el envío de notificaciones al flujo de guardado de combinadas.
- Se agregaron logs de diagnóstico:
  - notificación enviada correctamente,
  - notificación no enviada por configuración incompleta,
  - errores controlados de Telegram.
- Se evita imprimir tokens o credenciales en logs.
- Telegram queda deshabilitado por defecto para no romper CI ni entornos sin configuración.


